### PR TITLE
fix: resolve deadlock in LiveAudioCapture deinit

### DIFF
--- a/Sources/HPLiveKit/Capture/LiveAudioCapture.swift
+++ b/Sources/HPLiveKit/Capture/LiveAudioCapture.swift
@@ -92,8 +92,11 @@ class LiveAudioCapture: NSObject {
   }
   
   deinit {
-    taskQueue.sync {
-      self.running = false
+    // Fix: Use async instead of sync to avoid deadlock
+    // In deinit, sync will wait for the queue, but the setter is async,
+    // causing a deadlock. Using async or direct stopRunning() is safe.
+    taskQueue.async { [weak self] in
+      self?.captureSession.stopRunning()
     }
   }
   


### PR DESCRIPTION
## Summary

Fixed a critical deadlock issue in LiveAudioCapture.deinit.

## Problem

The original code used taskQueue.sync in deinit, which causes a deadlock because the running setter uses async internally.

## Solution

Replace with async to avoid blocking the queue.

## Testing

- Swift build: PASS

## Labels

- priority: critical
- type: bug