### PR TITLE
fix: 确保 LiveVideoCapture delegate 回调在主线程执行

### DIFF
--- a/Sources/HPLiveKit/Capture/LiveVideoCapture.swift
+++ b/Sources/HPLiveKit/Capture/LiveVideoCapture.swift
@@ -27,7 +27,16 @@ protocol VideoCaptureDelegate: AnyObject {
 
 extension LiveVideoCapture: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAudioDataOutputSampleBufferDelegate {
   func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
-    self.delegate?.captureOutput(capture: self, video: sampleBuffer)
+    // Deliver callback on main thread for UI-safe operations
+    // This is the expected behavior for most use cases
+    if Thread.isMainThread {
+      self.delegate?.captureOutput(capture: self, video: sampleBuffer)
+    } else {
+      DispatchQueue.main.async { [weak self] in
+        guard let self = self else { return }
+        self.delegate?.captureOutput(capture: self, video: sampleBuffer)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## 摘要

修复 LiveVideoCapture 中 delegate 回调线程安全问题。

## 问题描述

在  方法中，delegate 回调直接在 （后台队列）上执行，而不是在主线程。这可能导致：

1. **UI 更新问题**：如果 delegate 实现中包含 UI 更新代码，可能导致崩溃或未定义行为
2. **线程安全问题**：大多数 iOS 开发者期望 delegate 回调在主线程执行

## 修复方案

添加主线程检查：
- 如果当前已在主线程，直接调用 delegate
- 如果不在主线程，使用  切换到主线程
- 使用  避免潜在的循环引用

## 测试

- [ ] 在真机上测试视频采集
- [ ] 验证 delegate 回调确实在主线程执行

## 相关 Issue

- 可能解决 UI 相关崩溃问题

---
**Priority:** high
**Type:** bug, thread-safety