### PR TITLE
fix: AudioConverter resource leak in LiveAudioAACEncoder

### DIFF
--- a/Sources/HPLiveKit/Coder/LiveAudioAACEncoder.swift
+++ b/Sources/HPLiveKit/Coder/LiveAudioAACEncoder.swift
@@ -91,9 +91,14 @@ actor LiveAudioAACEncoder: AudioEncoder {
 
   func stop() {
     processingTask?.cancel()
+    processingTask = nil
     inputContinuation.finish()
     outputContinuation.finish()
 
+    // Critical: Dispose AudioConverter to prevent resource leak
+    if let converter = converter {
+      AudioConverterDispose(converter)
+    }
     converter = nil
     pcmDataBuffer.clear()
     audioHeader = nil
@@ -368,6 +373,10 @@ actor LiveAudioAACEncoder: AudioEncoder {
   }
 
   private func resetConverterState() {
+    // Critical: Dispose AudioConverter to prevent resource leak
+    if let converter = converter {
+      AudioConverterDispose(converter)
+    }
     converter = nil
     pcmDataBuffer.clear()
     bufferStartTimestamp = nil


### PR DESCRIPTION
## Summary

Critical bug fix: AudioConverter was not being properly disposed when the encoder stops or resets, causing resource leak.

## Changes

1. **stop() method**: Added  before setting converter to nil
2. **resetConverterState() method**: Added proper disposal of AudioConverter
3. **Task cleanup**: Set  to nil after cancel to prevent task reference leak

## Why This Matters

AudioConverter is a Core Audio component that holds system resources. Failing to dispose it leads to:
- Memory leak
- System resource exhaustion after multiple encoder restarts

## Testing

- xcodebuild: BUILD SUCCEEDED