### PR TITLE
fix: dispose AudioConverter to prevent resource leak

### DIFF
--- a/Sources/HPLiveKit/Coder/LiveAudioAACEncoder.swift
+++ b/Sources/HPLiveKit/Coder/LiveAudioAACEncoder.swift
@@ -94,6 +94,10 @@ actor LiveAudioAACEncoder: AudioEncoder {
     inputContinuation.finish()
     outputContinuation.finish()
 
+    // Dispose AudioConverter to prevent resource leak
+    if let converter = converter {
+      AudioConverterDispose(converter)
+    }
     converter = nil
     pcmDataBuffer.clear()
     audioHeader = nil
@@ -368,6 +372,10 @@ actor LiveAudioAACEncoder: AudioEncoder {
   }
 
   private func resetConverterState() {
+    // Dispose AudioConverter to prevent resource leak
+    if let converter = converter {
+      AudioConverterDispose(converter)
+    }
     converter = nil
     pcmDataBuffer.clear()
     bufferStartTimestamp = nil


### PR DESCRIPTION
## Summary

Fixes resource leak in LiveAudioAACEncoder by properly disposing AudioConverterRef when the encoder is stopped or reset.

## Problem

The stop() and resetConverterState() methods were setting converter to nil without calling AudioConverterDispose(), which is required to release the AudioConverter resources.

## Solution

Add AudioConverterDispose() calls before setting the converter to nil in both methods.

## Testing

- Built successfully with xcodebuild