### PR TITLE
fix: 修复 StreamingBuffer 计时器 Task 泄漏问题

### DIFF
--- a/Sources/HPLiveKit/Publish/RtmpPublisher.swift
+++ b/Sources/HPLiveKit/Publish/RtmpPublisher.swift
@@ -199,6 +199,7 @@ actor RtmpPublisher: Publisher {
     await rtmp.stop()
 
     await clean()
+    await buffer.stop()
   }
 
   private func clean() async {

--- a/Sources/HPLiveKit/Publish/StreamingBuffer.swift
+++ b/Sources/HPLiveKit/Publish/StreamingBuffer.swift
@@ -23,6 +23,9 @@ protocol StreamingBufferDelegate: AnyObject {
 }
 
 actor StreamingBuffer {
+
+  // Task for timer to prevent Task leak
+  private var timerTask: Task<Void, Never>?
   private static let defaultSortBufferMaxCount = UInt(5) ///< 排序10个内
   private static let defaultUpdateInterval = UInt(1) ///< 更新频率为1s
   private static let defaultCallBackInterval = UInt(5) ///< 5s计时一次
@@ -172,6 +175,13 @@ actor StreamingBuffer {
     return .unknown
   }
   
+  // Stop the timer
+  func stop() {
+    timerTask?.cancel()
+    timerTask = nil
+    startTimer = false
+  }
+
   // -- 采样
   private func tick() {
     /** 采样 3个阶段   如果网络都是好或者都是差给回调 */
@@ -191,7 +201,7 @@ actor StreamingBuffer {
       thresholdList.removeAll()
     }
     
-    Task {
+    timerTask = Task {
       try? await Task.sleep(nanoseconds: UInt64(updateInterval) * 1000000)
       tick()
     }


### PR DESCRIPTION
## 问题描述

StreamingBuffer 中的 tick() 方法使用递归 Task 调用来定期采样缓冲区状态，但每次调用都创建新的 Task 而不存储引用，导致潜在的 Task 泄漏问题。

## 解决方案

1. 添加 `timerTask` 变量来存储计时器 Task 引用
2. 添加 `stop()` 方法用于停止计时器并清理资源
3. 在 `RtmpPublisher.stop()` 中调用 `buffer.stop()` 确保资源正确释放

## 修改文件

- `Sources/HPLiveKit/Publish/StreamingBuffer.swift` - 添加 timerTask 和 stop 方法
- `Sources/HPLiveKit/Publish/RtmpPublisher.swift` - 在 stop 方法中调用 buffer.stop()

## 优先级
- 优先级：Medium
- 类型：Concurrency (Task 泄漏修复)