### PR TITLE
fix: make stopLive() async and properly stop audioMixer

### DIFF
--- a/Example/HPLiveKit/ViewController.swift
+++ b/Example/HPLiveKit/ViewController.swift
@@ -31,6 +31,12 @@ class ViewController: UIViewController {
   }
   
   @objc private func buttonTapped() {
+    Task {
+      await handleButtonTapped()
+    }
+  }
+
+  private func handleButtonTapped() async {
     switch liveState {
     case .ready, .stop, .error:
       let info = LiveStreamInfo(url: "rtmp://192.168.11.23:1936/live/haha")
@@ -38,7 +44,7 @@ class ViewController: UIViewController {
       liveState = .start
       button.setTitle("Stop", for: .normal)
     case .start:
-      liveSession?.stopLive()
+      await liveSession?.stopLive()
       liveState = .stop
       button.setTitle("Publish", for: .normal)
     default:

--- a/Sources/HPLiveKit/LiveSession.swift
+++ b/Sources/HPLiveKit/LiveSession.swift
@@ -272,13 +272,14 @@ public class LiveSession: NSObject, @unchecked Sendable {
     }
   }
   
-  public func stopLive() {
-    Task {
-      uploading = false
-      
-      await publisher?.stop()
-      publisher = nil
-    }
+  public func stopLive() async {
+    uploading = false
+    
+    // Stop audio mixer if exists
+    await audioMixer?.stop()
+    
+    await publisher?.stop()
+    publisher = nil
   }
 
     public func startCapturing() {


### PR DESCRIPTION
## Summary

修复 LiveSession 中的 stopLive() 方法问题：

1. **问题**: stopLive() 之前是非 async 函数，内部使用 Task 但没有等待完成，可能导致 publisher 停止不完全
2. **修复**: 将 stopLive() 改为 async 函数，确保正确等待清理完成
3. **新增**: 在 stopLive() 中添加 audioMixer?.stop() 调用，确保屏幕共享模式下的音频混合器正确清理

## Changes

- LiveSession.stopLive() 改为 async 函数
- 添加 audioMixer 停止逻辑
- 更新示例应用以适配新的 async API

## Testing

- [x] Build: PASS