### PR TITLE
fix: prevent StreamingBuffer timer Task leak

### DIFF
--- a/Sources/HPLiveKit/Publish/RtmpPublisher.swift
+++ b/Sources/HPLiveKit/Publish/RtmpPublisher.swift
@@ -198,6 +198,7 @@ actor RtmpPublisher: Publisher {
 
     await rtmp.stop()
 
+    await buffer.stop()
     await clean()
   }
 

--- a/Sources/HPLiveKit/Publish/StreamingBuffer.swift
+++ b/Sources/HPLiveKit/Publish/StreamingBuffer.swift
@@ -51,6 +51,9 @@ actor StreamingBuffer {
   private var callBackInterval: UInt = StreamingBuffer.defaultCallBackInterval
   private var updateInterval: UInt = StreamingBuffer.defaultUpdateInterval
   private var startTimer: Bool = false
+
+  // Timer task for periodic buffer state checking
+  private var timerTask: Task<Void, Never>?
   
   var isEmpty: Bool {
     list.isEmpty
@@ -98,6 +101,13 @@ actor StreamingBuffer {
   /** remove all objects from Buffer */
   func removeAll() {
     list.removeAll()
+  }
+
+  /** stop the timer task */
+  func stop() {
+    timerTask?.cancel()
+    timerTask = nil
+    startTimer = false
   }
   
   init() {
@@ -191,7 +201,7 @@ actor StreamingBuffer {
       thresholdList.removeAll()
     }
     
-    Task {
+    timerTask = Task {
       try? await Task.sleep(nanoseconds: UInt64(updateInterval) * 1000000)
       tick()
     }


### PR DESCRIPTION
防止 StreamingBuffer 的周期性计时器 Task 泄漏

添加 timerTask 变量跟踪 Task 引用，添加 stop() 方法用于取消并清理计时器 Task，在 RtmpPublisher.stop() 中调用 buffer.stop() 确保清理。