### PR TITLE
feat: multi-destination RTMP publishing (PublisherManager)

### DIFF
--- a/Sources/HPLiveKit/LiveSession.swift
+++ b/Sources/HPLiveKit/LiveSession.swift
@@ -64,16 +64,16 @@ public protocol LiveSessionDelegate: AnyObject, Sendable {
     func liveSession(session: LiveSession, debugInfo: LiveDebug)
 
     // Per-publisher callbacks (multi-stream support)
-    func liveSession(session: LiveSession, url: String, liveStateDidChange state: LiveState)
-    func liveSession(session: LiveSession, url: String, errorCode: LiveSocketErrorCode)
-    func liveSession(session: LiveSession, url: String, debugInfo: LiveDebug)
+    func liveSession(session: LiveSession, streamInfo: LiveStreamInfo, liveStateDidChange state: LiveState)
+    func liveSession(session: LiveSession, streamInfo: LiveStreamInfo, errorCode: LiveSocketErrorCode)
+    func liveSession(session: LiveSession, streamInfo: LiveStreamInfo, debugInfo: LiveDebug)
 }
 
 extension LiveSessionDelegate {
     public func liveSession(session: LiveSession, debugInfo: LiveDebug) {}
-    public func liveSession(session: LiveSession, url: String, liveStateDidChange state: LiveState) {}
-    public func liveSession(session: LiveSession, url: String, errorCode: LiveSocketErrorCode) {}
-    public func liveSession(session: LiveSession, url: String, debugInfo: LiveDebug) {}
+    public func liveSession(session: LiveSession, streamInfo: LiveStreamInfo, liveStateDidChange state: LiveState) {}
+    public func liveSession(session: LiveSession, streamInfo: LiveStreamInfo, errorCode: LiveSocketErrorCode) {}
+    public func liveSession(session: LiveSession, streamInfo: LiveStreamInfo, debugInfo: LiveDebug) {}
 }
 
 public class LiveSession: NSObject, @unchecked Sendable {
@@ -452,8 +452,8 @@ extension LiveSession: PublisherManagerDelegate {
         }
     }
 
-    func publisherManager(_ manager: PublisherManager, url: String, stateDidChange state: LiveState) {
-        delegate?.liveSession(session: self, url: url, liveStateDidChange: state)
+    func publisherManager(_ manager: PublisherManager, streamInfo: LiveStreamInfo, stateDidChange state: LiveState) {
+        delegate?.liveSession(session: self, streamInfo: streamInfo, liveStateDidChange: state)
         Task { [weak self] in
             guard let self else { return }
             let aggregated = await manager.aggregatedState
@@ -471,8 +471,8 @@ extension LiveSession: PublisherManagerDelegate {
         }
     }
 
-    func publisherManager(_ manager: PublisherManager, url: String, errorCode: LiveSocketErrorCode) {
-        delegate?.liveSession(session: self, url: url, errorCode: errorCode)
+    func publisherManager(_ manager: PublisherManager, streamInfo: LiveStreamInfo, errorCode: LiveSocketErrorCode) {
+        delegate?.liveSession(session: self, streamInfo: streamInfo, errorCode: errorCode)
         Task { [weak self] in
             guard let self else { return }
             if await manager.aggregatedState == .error {
@@ -481,8 +481,8 @@ extension LiveSession: PublisherManagerDelegate {
         }
     }
 
-    func publisherManager(_ manager: PublisherManager, url: String, debugInfo: LiveDebug) {
+    func publisherManager(_ manager: PublisherManager, streamInfo: LiveStreamInfo, debugInfo: LiveDebug) {
         self.debugInfo = debugInfo
-        delegate?.liveSession(session: self, url: url, debugInfo: debugInfo)
+        delegate?.liveSession(session: self, streamInfo: streamInfo, debugInfo: debugInfo)
     }
 }

--- a/Sources/HPLiveKit/LiveSession.swift
+++ b/Sources/HPLiveKit/LiveSession.swift
@@ -62,10 +62,18 @@ public protocol LiveSessionDelegate: AnyObject, Sendable {
 
     ///** live debug info callback */
     func liveSession(session: LiveSession, debugInfo: LiveDebug)
+
+    // Per-publisher callbacks (multi-stream support)
+    func liveSession(session: LiveSession, url: String, liveStateDidChange state: LiveState)
+    func liveSession(session: LiveSession, url: String, errorCode: LiveSocketErrorCode)
+    func liveSession(session: LiveSession, url: String, debugInfo: LiveDebug)
 }
 
 extension LiveSessionDelegate {
-    func liveSession(session: LiveSession, debugInfo: LiveDebug) {}
+    public func liveSession(session: LiveSession, debugInfo: LiveDebug) {}
+    public func liveSession(session: LiveSession, url: String, liveStateDidChange state: LiveState) {}
+    public func liveSession(session: LiveSession, url: String, errorCode: LiveSocketErrorCode) {}
+    public func liveSession(session: LiveSession, url: String, debugInfo: LiveDebug) {}
 }
 
 public class LiveSession: NSObject, @unchecked Sendable {
@@ -96,16 +104,14 @@ public class LiveSession: NSObject, @unchecked Sendable {
     private var videoEncoderTask: Task<Void, Never>?
     private var mixerTask: Task<Void, Never>?
 
-    // 推流 publisher
-    private var publisher: Publisher?
+    // 推流 publisher manager
+    private let publisherManager = PublisherManager()
 
     // Audio mixer (only for screenShare mode)
     private var audioMixer: AudioMixer?
 
     // 调试信息 debug info
     private var debugInfo: LiveDebug?
-    // 流信息 stream info
-    private var streamInfo: LiveStreamInfo?
     // 是否开始上传  is publishing
     private var uploading: Bool = false
     // 当前状态 current live stream state
@@ -249,37 +255,39 @@ public class LiveSession: NSObject, @unchecked Sendable {
         mixerTask?.cancel()
     }
 
-  public func startLive(streamInfo: LiveStreamInfo) {
-    Task {
-      var mutableStreamInfo = streamInfo
-
-      mutableStreamInfo.audioConfiguration = audioConfiguration
-      mutableStreamInfo.videoConfiguration = videoConfiguration
-
-      self.streamInfo = mutableStreamInfo
-
-      if publisher == nil {
-        publisher = createRTMPPublisher()
-        await publisher?.setDelegate(delegate: self)
-      }
-
-      // Ensure frame processing task is running
-      if frameProcessingTask == nil || frameProcessingTask?.isCancelled == true {
-        startFrameProcessing()
-      }
-
-      await publisher?.start()
+    public func startLive(streamInfo: LiveStreamInfo) {
+        startLive(streamInfos: [streamInfo])
     }
-  }
-  
-  public func stopLive() {
-    Task {
-      uploading = false
-      
-      await publisher?.stop()
-      publisher = nil
+
+    public func startLive(streamInfos: [LiveStreamInfo]) {
+        Task { [weak self] in
+            guard let self else { return }
+            await publisherManager.stopAll()
+            await publisherManager.removeAll()
+
+            for streamInfo in streamInfos {
+                var info = streamInfo
+                info.audioConfiguration = audioConfiguration
+                info.videoConfiguration = videoConfiguration
+                await publisherManager.add(streamInfo: info)
+            }
+
+            await publisherManager.setDelegate(self)
+
+            if frameProcessingTask == nil || frameProcessingTask?.isCancelled == true {
+                startFrameProcessing()
+            }
+
+            await publisherManager.startAll()
+        }
     }
-  }
+
+    public func stopLive() {
+        Task {
+            uploading = false
+            await publisherManager.stopAll()
+        }
+    }
 
     public func startCapturing() {
         // Screen share mode does not use internal capture
@@ -327,27 +335,13 @@ public class LiveSession: NSObject, @unchecked Sendable {
 }
 
 private extension LiveSession {
-    func createRTMPPublisher() -> Publisher {
-        guard let streamInfo = streamInfo else {
-            fatalError("[HPLiveKit] streamInfo can not be nil!!!")
-        }
 
-        return RtmpPublisher(stream: streamInfo)
-    }
-}
-
-private extension LiveSession {
-
-    /// Start the frame processing task that sequentially processes frames from the stream
     func startFrameProcessing() {
         frameProcessingTask?.cancel()
         frameProcessingTask = Task { [weak self] in
-            guard let self = self else { return }
-
-            // Process frames sequentially in the order they are yielded
-            // This ensures timestamp ordering is preserved
+            guard let self else { return }
             for await frame in self.frameStream {
-                await publisher?.send(frame: frame)
+                await self.publisherManager.send(frame: frame)
             }
         }
     }
@@ -434,62 +428,61 @@ extension LiveSession: CaptureManagerDelegate {
   }
 }
 
-extension LiveSession: PublisherDelegate {
-    func publisher(publisher: Publisher, publishStatus: LiveState) {
-        // reset status and start uploading data
-        if publishStatus == .start && !uploading {
-            hasCapturedAudio = false
-            hasCapturedKeyFrame = false
-            timestampSynchronizer.reset()  // Reset timestamp to start from 0
-            uploading = true
-        }
-
-        // stop uploading
-        if publishStatus == .stop || publishStatus == .error {
-            uploading = false
-        }
-
-        self.state = publishStatus
-        delegate?.liveSession(session: self, liveStateDidChange: publishStatus)
-    }
-
-    func publisher(publisher: Publisher, bufferStatus: BufferState) {
-        // only adjust video bitrate, audio cannot
+extension LiveSession: PublisherManagerDelegate {
+    func publisherManager(_ manager: PublisherManager, aggregatedBufferStatus: BufferState) {
         guard captureType.contains(.captureVideo) && adaptiveVideoBitrate else { return }
-
-        // Adjust video bitrate asynchronously (encoder is Actor-based)
         Task { [weak self] in
-            guard let self = self else { return }
-
+            guard let self else { return }
             let videoBitRate = await self.videoEncoder.currentVideoBitRate
-
-            if bufferStatus == .decline && videoBitRate < self.videoConfiguration.videoMaxBitRate {
-                let adjustedVideoBitRate = min(videoBitRate + 50 * 1000, self.videoConfiguration.videoMaxBitRate)
-                await self.videoEncoder.setVideoBitRate(adjustedVideoBitRate)
+            if aggregatedBufferStatus == .decline && videoBitRate < self.videoConfiguration.videoMaxBitRate {
+                let adjusted = min(videoBitRate + 50 * 1000, self.videoConfiguration.videoMaxBitRate)
+                await self.videoEncoder.setVideoBitRate(adjusted)
                 #if DEBUG
-                print("[HPLiveKit] Increase bitrate \(videoBitRate) --> \(adjustedVideoBitRate)")
+                print("[HPLiveKit] Increase bitrate \(videoBitRate) --> \(adjusted)")
                 #endif
                 return
             }
-
-            if bufferStatus == .increase && videoBitRate > self.videoConfiguration.videoMinBitRate {
-                let adjustedVideoBitRate = max(videoBitRate - 100 * 1000, self.videoConfiguration.videoMinBitRate)
-                await self.videoEncoder.setVideoBitRate(adjustedVideoBitRate)
+            if aggregatedBufferStatus == .increase && videoBitRate > self.videoConfiguration.videoMinBitRate {
+                let adjusted = max(videoBitRate - 100 * 1000, self.videoConfiguration.videoMinBitRate)
+                await self.videoEncoder.setVideoBitRate(adjusted)
                 #if DEBUG
-                print("[HPLiveKit] Decline bitrate \(videoBitRate) --> \(adjustedVideoBitRate)")
+                print("[HPLiveKit] Decline bitrate \(videoBitRate) --> \(adjusted)")
                 #endif
-                return
             }
         }
     }
 
-    func publisher(publisher: Publisher, errorCode: LiveSocketErrorCode) {
-        delegate?.liveSession(session: self, errorCode: errorCode)
+    func publisherManager(_ manager: PublisherManager, url: String, stateDidChange state: LiveState) {
+        delegate?.liveSession(session: self, url: url, liveStateDidChange: state)
+        Task { [weak self] in
+            guard let self else { return }
+            let aggregated = await manager.aggregatedState
+            if aggregated == .start && !self.uploading {
+                self.hasCapturedAudio = false
+                self.hasCapturedKeyFrame = false
+                self.timestampSynchronizer.reset()
+                self.uploading = true
+            }
+            if aggregated == .stop || aggregated == .error {
+                self.uploading = false
+            }
+            self.state = aggregated
+            self.delegate?.liveSession(session: self, liveStateDidChange: aggregated)
+        }
     }
 
-    func publisher(publisher: Publisher, debugInfo: LiveDebug) {
+    func publisherManager(_ manager: PublisherManager, url: String, errorCode: LiveSocketErrorCode) {
+        delegate?.liveSession(session: self, url: url, errorCode: errorCode)
+        Task { [weak self] in
+            guard let self else { return }
+            if await manager.aggregatedState == .error {
+                self.delegate?.liveSession(session: self, errorCode: errorCode)
+            }
+        }
+    }
+
+    func publisherManager(_ manager: PublisherManager, url: String, debugInfo: LiveDebug) {
         self.debugInfo = debugInfo
-        delegate?.liveSession(session: self, debugInfo: debugInfo)
+        delegate?.liveSession(session: self, url: url, debugInfo: debugInfo)
     }
-
 }

--- a/Sources/HPLiveKit/Objects/LiveDebug.swift
+++ b/Sources/HPLiveKit/Objects/LiveDebug.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct LiveDebug {
+public struct LiveDebug: Sendable {
   /// Stream URLs
   var uploadUrl: String?
   /// Uploaded resolution

--- a/Sources/HPLiveKit/Objects/LiveStreamInfo.swift
+++ b/Sources/HPLiveKit/Objects/LiveStreamInfo.swift
@@ -39,17 +39,19 @@ public enum LiveSocketErrorCode: Int, Sendable {
 }
 
 // Stream Information
-public struct LiveStreamInfo: Sendable {
-  // --- RTMP ---
-  
+public struct LiveStreamInfo: Sendable, Equatable {
+  public let id: String
   public let url: String
-  
-  /// Audio Configuration
+
   var audioConfiguration: LiveAudioConfiguration?
-  /// Video Configuration
   var videoConfiguration: LiveVideoConfiguration?
-  
-  public init(url: String) {
+
+  public init(url: String, id: String = UUID().uuidString) {
+    self.id = id
     self.url = url
+  }
+
+  public static func == (lhs: LiveStreamInfo, rhs: LiveStreamInfo) -> Bool {
+    lhs.id == rhs.id
   }
 }

--- a/Sources/HPLiveKit/Publish/PublisherManager.swift
+++ b/Sources/HPLiveKit/Publish/PublisherManager.swift
@@ -1,0 +1,144 @@
+//
+//  PublisherManager.swift
+//  HPLiveKit
+//
+
+import Foundation
+
+protocol PublisherManagerDelegate: AnyObject, Sendable {
+    func publisherManager(_ manager: PublisherManager, aggregatedBufferStatus: BufferState)
+    func publisherManager(_ manager: PublisherManager, url: String, stateDidChange state: LiveState)
+    func publisherManager(_ manager: PublisherManager, url: String, errorCode: LiveSocketErrorCode)
+    func publisherManager(_ manager: PublisherManager, url: String, debugInfo: LiveDebug)
+}
+
+// Per-publisher delegate bridge carrying URL context.
+// Uses nonisolated + Task pattern (same as RtmpPublisher: StreamingBufferDelegate).
+final class PublisherDelegateBridge: PublisherDelegate, @unchecked Sendable {
+    let url: String
+    weak var manager: PublisherManager?
+
+    init(url: String, manager: PublisherManager) {
+        self.url = url
+        self.manager = manager
+    }
+
+    func publisher(publisher: Publisher, bufferStatus: BufferState) {
+        Task { await manager?.handleBufferStatus(from: url, status: bufferStatus) }
+    }
+
+    func publisher(publisher: Publisher, publishStatus: LiveState) {
+        Task { await manager?.handleStateChange(from: url, state: publishStatus) }
+    }
+
+    func publisher(publisher: Publisher, errorCode: LiveSocketErrorCode) {
+        Task { await manager?.handleError(from: url, error: errorCode) }
+    }
+
+    func publisher(publisher: Publisher, debugInfo: LiveDebug) {
+        Task { await manager?.handleDebugInfo(from: url, info: debugInfo) }
+    }
+}
+
+actor PublisherManager {
+    private struct PublisherEntry {
+        let publisher: any Publisher
+        let streamInfo: LiveStreamInfo
+        // Strong reference needed because RtmpPublisher holds only weak delegate
+        let delegateBridge: PublisherDelegateBridge
+        var state: LiveState = .ready
+    }
+
+    private var publishers: [String: PublisherEntry] = [:]
+    private var publisherBufferStates: [String: BufferState] = [:]
+    weak var delegate: (any PublisherManagerDelegate)?
+
+    func setDelegate(_ delegate: (any PublisherManagerDelegate)?) {
+        self.delegate = delegate
+    }
+
+    func add(streamInfo: LiveStreamInfo) async {
+        let publisher = RtmpPublisher(stream: streamInfo)
+        await add(publisher: publisher, for: streamInfo)
+    }
+
+    // Allows injecting a pre-built publisher; used by unit tests.
+    func add(publisher: any Publisher, for streamInfo: LiveStreamInfo) async {
+        let url = streamInfo.url
+        let bridge = PublisherDelegateBridge(url: url, manager: self)
+        await publisher.setDelegate(delegate: bridge)
+        publishers[url] = PublisherEntry(publisher: publisher, streamInfo: streamInfo, delegateBridge: bridge)
+    }
+
+    func removeAll() async {
+        publishers.removeAll()
+        publisherBufferStates.removeAll()
+    }
+
+    func startAll() async {
+        await withTaskGroup(of: Void.self) { group in
+            for entry in publishers.values {
+                group.addTask { await entry.publisher.start() }
+            }
+        }
+    }
+
+    func stopAll() async {
+        await withTaskGroup(of: Void.self) { group in
+            for entry in publishers.values {
+                group.addTask { await entry.publisher.stop() }
+            }
+        }
+    }
+
+    func send(frame: any Frame) async {
+        await withTaskGroup(of: Void.self) { group in
+            for entry in publishers.values {
+                group.addTask { await entry.publisher.send(frame: frame) }
+            }
+        }
+    }
+
+    // Any .start -> overall .start; all .error -> overall .error; all .stop -> overall .stop
+    var aggregatedState: LiveState {
+        let states = publishers.values.map { $0.state }
+        if states.isEmpty { return .ready }
+        if states.contains(.start) { return .start }
+        if states.allSatisfy({ $0 == .error }) { return .error }
+        if states.allSatisfy({ $0 == .stop }) { return .stop }
+        if states.contains(.pending) { return .pending }
+        return states.first ?? .ready
+    }
+
+    var isEmpty: Bool { publishers.isEmpty }
+
+    func handleBufferStatus(from url: String, status: BufferState) {
+        publisherBufferStates[url] = status
+        // Most conservative signal wins: any slow path triggers bitrate decrease
+        if publisherBufferStates.values.contains(where: { $0 == .increase }) {
+            delegate?.publisherManager(self, aggregatedBufferStatus: .increase)
+            return
+        }
+        // Only increase bitrate when all registered publishers have reported decline
+        if publisherBufferStates.count == publishers.count &&
+           publisherBufferStates.values.allSatisfy({ $0 == .decline }) {
+            delegate?.publisherManager(self, aggregatedBufferStatus: .decline)
+        }
+    }
+
+    func handleStateChange(from url: String, state: LiveState) {
+        if var entry = publishers[url] {
+            entry.state = state
+            publishers[url] = entry
+        }
+        delegate?.publisherManager(self, url: url, stateDidChange: state)
+    }
+
+    func handleError(from url: String, error: LiveSocketErrorCode) {
+        delegate?.publisherManager(self, url: url, errorCode: error)
+    }
+
+    func handleDebugInfo(from url: String, info: LiveDebug) {
+        delegate?.publisherManager(self, url: url, debugInfo: info)
+    }
+}

--- a/Sources/HPLiveKit/Publish/PublisherManager.swift
+++ b/Sources/HPLiveKit/Publish/PublisherManager.swift
@@ -7,36 +7,36 @@ import Foundation
 
 protocol PublisherManagerDelegate: AnyObject, Sendable {
     func publisherManager(_ manager: PublisherManager, aggregatedBufferStatus: BufferState)
-    func publisherManager(_ manager: PublisherManager, url: String, stateDidChange state: LiveState)
-    func publisherManager(_ manager: PublisherManager, url: String, errorCode: LiveSocketErrorCode)
-    func publisherManager(_ manager: PublisherManager, url: String, debugInfo: LiveDebug)
+    func publisherManager(_ manager: PublisherManager, streamInfo: LiveStreamInfo, stateDidChange state: LiveState)
+    func publisherManager(_ manager: PublisherManager, streamInfo: LiveStreamInfo, errorCode: LiveSocketErrorCode)
+    func publisherManager(_ manager: PublisherManager, streamInfo: LiveStreamInfo, debugInfo: LiveDebug)
 }
 
-// Per-publisher delegate bridge carrying URL context.
+// Per-publisher delegate bridge carrying stream identity context.
 // Uses nonisolated + Task pattern (same as RtmpPublisher: StreamingBufferDelegate).
 final class PublisherDelegateBridge: PublisherDelegate, @unchecked Sendable {
-    let url: String
+    let streamInfo: LiveStreamInfo
     weak var manager: PublisherManager?
 
-    init(url: String, manager: PublisherManager) {
-        self.url = url
+    init(streamInfo: LiveStreamInfo, manager: PublisherManager) {
+        self.streamInfo = streamInfo
         self.manager = manager
     }
 
     func publisher(publisher: Publisher, bufferStatus: BufferState) {
-        Task { await manager?.handleBufferStatus(from: url, status: bufferStatus) }
+        Task { await manager?.handleBufferStatus(from: streamInfo.id, status: bufferStatus) }
     }
 
     func publisher(publisher: Publisher, publishStatus: LiveState) {
-        Task { await manager?.handleStateChange(from: url, state: publishStatus) }
+        Task { await manager?.handleStateChange(from: streamInfo.id, state: publishStatus) }
     }
 
     func publisher(publisher: Publisher, errorCode: LiveSocketErrorCode) {
-        Task { await manager?.handleError(from: url, error: errorCode) }
+        Task { await manager?.handleError(from: streamInfo.id, error: errorCode) }
     }
 
     func publisher(publisher: Publisher, debugInfo: LiveDebug) {
-        Task { await manager?.handleDebugInfo(from: url, info: debugInfo) }
+        Task { await manager?.handleDebugInfo(from: streamInfo.id, info: debugInfo) }
     }
 }
 
@@ -49,8 +49,8 @@ actor PublisherManager {
         var state: LiveState = .ready
     }
 
-    private var publishers: [String: PublisherEntry] = [:]
-    private var publisherBufferStates: [String: BufferState] = [:]
+    private var publishers: [String: PublisherEntry] = [:]          // keyed by id
+    private var publisherBufferStates: [String: BufferState] = [:]   // keyed by id
     weak var delegate: (any PublisherManagerDelegate)?
 
     func setDelegate(_ delegate: (any PublisherManagerDelegate)?) {
@@ -64,10 +64,9 @@ actor PublisherManager {
 
     // Allows injecting a pre-built publisher; used by unit tests.
     func add(publisher: any Publisher, for streamInfo: LiveStreamInfo) async {
-        let url = streamInfo.url
-        let bridge = PublisherDelegateBridge(url: url, manager: self)
+        let bridge = PublisherDelegateBridge(streamInfo: streamInfo, manager: self)
         await publisher.setDelegate(delegate: bridge)
-        publishers[url] = PublisherEntry(publisher: publisher, streamInfo: streamInfo, delegateBridge: bridge)
+        publishers[streamInfo.id] = PublisherEntry(publisher: publisher, streamInfo: streamInfo, delegateBridge: bridge)
     }
 
     func removeAll() async {
@@ -112,8 +111,8 @@ actor PublisherManager {
 
     var isEmpty: Bool { publishers.isEmpty }
 
-    func handleBufferStatus(from url: String, status: BufferState) {
-        publisherBufferStates[url] = status
+    func handleBufferStatus(from id: String, status: BufferState) {
+        publisherBufferStates[id] = status
         // Most conservative signal wins: any slow path triggers bitrate decrease
         if publisherBufferStates.values.contains(where: { $0 == .increase }) {
             delegate?.publisherManager(self, aggregatedBufferStatus: .increase)
@@ -126,19 +125,22 @@ actor PublisherManager {
         }
     }
 
-    func handleStateChange(from url: String, state: LiveState) {
-        if var entry = publishers[url] {
+    func handleStateChange(from id: String, state: LiveState) {
+        if var entry = publishers[id] {
             entry.state = state
-            publishers[url] = entry
+            publishers[id] = entry
         }
-        delegate?.publisherManager(self, url: url, stateDidChange: state)
+        guard let streamInfo = publishers[id]?.streamInfo else { return }
+        delegate?.publisherManager(self, streamInfo: streamInfo, stateDidChange: state)
     }
 
-    func handleError(from url: String, error: LiveSocketErrorCode) {
-        delegate?.publisherManager(self, url: url, errorCode: error)
+    func handleError(from id: String, error: LiveSocketErrorCode) {
+        guard let streamInfo = publishers[id]?.streamInfo else { return }
+        delegate?.publisherManager(self, streamInfo: streamInfo, errorCode: error)
     }
 
-    func handleDebugInfo(from url: String, info: LiveDebug) {
-        delegate?.publisherManager(self, url: url, debugInfo: info)
+    func handleDebugInfo(from id: String, info: LiveDebug) {
+        guard let streamInfo = publishers[id]?.streamInfo else { return }
+        delegate?.publisherManager(self, streamInfo: streamInfo, debugInfo: info)
     }
 }

--- a/Tests/HPLiveKitTests/PublisherManagerTests.swift
+++ b/Tests/HPLiveKitTests/PublisherManagerTests.swift
@@ -48,24 +48,24 @@ actor MockPublisher: Publisher {
 
 final class MockPublisherManagerDelegate: PublisherManagerDelegate, @unchecked Sendable {
     var aggregatedBufferStatuses: [BufferState] = []
-    var stateChanges: [(url: String, state: LiveState)] = []
-    var errors: [(url: String, code: LiveSocketErrorCode)] = []
-    var debugInfos: [(url: String, info: LiveDebug)] = []
+    var stateChanges: [(streamInfo: LiveStreamInfo, state: LiveState)] = []
+    var errors: [(streamInfo: LiveStreamInfo, code: LiveSocketErrorCode)] = []
+    var debugInfos: [(streamInfo: LiveStreamInfo, info: LiveDebug)] = []
 
     func publisherManager(_ manager: PublisherManager, aggregatedBufferStatus: BufferState) {
         aggregatedBufferStatuses.append(aggregatedBufferStatus)
     }
 
-    func publisherManager(_ manager: PublisherManager, url: String, stateDidChange state: LiveState) {
-        stateChanges.append((url: url, state: state))
+    func publisherManager(_ manager: PublisherManager, streamInfo: LiveStreamInfo, stateDidChange state: LiveState) {
+        stateChanges.append((streamInfo: streamInfo, state: state))
     }
 
-    func publisherManager(_ manager: PublisherManager, url: String, errorCode: LiveSocketErrorCode) {
-        errors.append((url: url, code: errorCode))
+    func publisherManager(_ manager: PublisherManager, streamInfo: LiveStreamInfo, errorCode: LiveSocketErrorCode) {
+        errors.append((streamInfo: streamInfo, code: errorCode))
     }
 
-    func publisherManager(_ manager: PublisherManager, url: String, debugInfo: LiveDebug) {
-        debugInfos.append((url: url, info: debugInfo))
+    func publisherManager(_ manager: PublisherManager, streamInfo: LiveStreamInfo, debugInfo: LiveDebug) {
+        debugInfos.append((streamInfo: streamInfo, info: debugInfo))
     }
 }
 
@@ -175,14 +175,16 @@ final class PublisherManagerTests: XCTestCase {
         let delegate = MockPublisherManagerDelegate()
         await manager.setDelegate(delegate)
 
+        let info1 = LiveStreamInfo(url: "rtmp://a.com/1")
+        let info2 = LiveStreamInfo(url: "rtmp://b.com/2")
         let pub1 = MockPublisher()
         let pub2 = MockPublisher()
-        await manager.add(publisher: pub1, for: LiveStreamInfo(url: "rtmp://a.com/1"))
-        await manager.add(publisher: pub2, for: LiveStreamInfo(url: "rtmp://b.com/2"))
+        await manager.add(publisher: pub1, for: info1)
+        await manager.add(publisher: pub2, for: info2)
 
         // Trigger state changes via delegate bridge
-        await manager.handleStateChange(from: "rtmp://a.com/1", state: .start)
-        await manager.handleStateChange(from: "rtmp://b.com/2", state: .stop)
+        await manager.handleStateChange(from: info1.id, state: .start)
+        await manager.handleStateChange(from: info2.id, state: .stop)
 
         let state = await manager.aggregatedState
         XCTAssertEqual(state, .start)
@@ -190,13 +192,15 @@ final class PublisherManagerTests: XCTestCase {
 
     func testAggregatedStateAllStopIsStop() async {
         let manager = PublisherManager()
+        let info1 = LiveStreamInfo(url: "rtmp://a.com/1")
+        let info2 = LiveStreamInfo(url: "rtmp://b.com/2")
         let pub1 = MockPublisher()
         let pub2 = MockPublisher()
-        await manager.add(publisher: pub1, for: LiveStreamInfo(url: "rtmp://a.com/1"))
-        await manager.add(publisher: pub2, for: LiveStreamInfo(url: "rtmp://b.com/2"))
+        await manager.add(publisher: pub1, for: info1)
+        await manager.add(publisher: pub2, for: info2)
 
-        await manager.handleStateChange(from: "rtmp://a.com/1", state: .stop)
-        await manager.handleStateChange(from: "rtmp://b.com/2", state: .stop)
+        await manager.handleStateChange(from: info1.id, state: .stop)
+        await manager.handleStateChange(from: info2.id, state: .stop)
 
         let state = await manager.aggregatedState
         XCTAssertEqual(state, .stop)
@@ -204,13 +208,15 @@ final class PublisherManagerTests: XCTestCase {
 
     func testAggregatedStateAllErrorIsError() async {
         let manager = PublisherManager()
+        let info1 = LiveStreamInfo(url: "rtmp://a.com/1")
+        let info2 = LiveStreamInfo(url: "rtmp://b.com/2")
         let pub1 = MockPublisher()
         let pub2 = MockPublisher()
-        await manager.add(publisher: pub1, for: LiveStreamInfo(url: "rtmp://a.com/1"))
-        await manager.add(publisher: pub2, for: LiveStreamInfo(url: "rtmp://b.com/2"))
+        await manager.add(publisher: pub1, for: info1)
+        await manager.add(publisher: pub2, for: info2)
 
-        await manager.handleStateChange(from: "rtmp://a.com/1", state: .error)
-        await manager.handleStateChange(from: "rtmp://b.com/2", state: .error)
+        await manager.handleStateChange(from: info1.id, state: .error)
+        await manager.handleStateChange(from: info2.id, state: .error)
 
         let state = await manager.aggregatedState
         XCTAssertEqual(state, .error)
@@ -218,13 +224,15 @@ final class PublisherManagerTests: XCTestCase {
 
     func testAggregatedStateMixedErrorAndStopIsNotError() async {
         let manager = PublisherManager()
+        let info1 = LiveStreamInfo(url: "rtmp://a.com/1")
+        let info2 = LiveStreamInfo(url: "rtmp://b.com/2")
         let pub1 = MockPublisher()
         let pub2 = MockPublisher()
-        await manager.add(publisher: pub1, for: LiveStreamInfo(url: "rtmp://a.com/1"))
-        await manager.add(publisher: pub2, for: LiveStreamInfo(url: "rtmp://b.com/2"))
+        await manager.add(publisher: pub1, for: info1)
+        await manager.add(publisher: pub2, for: info2)
 
-        await manager.handleStateChange(from: "rtmp://a.com/1", state: .error)
-        await manager.handleStateChange(from: "rtmp://b.com/2", state: .stop)
+        await manager.handleStateChange(from: info1.id, state: .error)
+        await manager.handleStateChange(from: info2.id, state: .stop)
 
         let state = await manager.aggregatedState
         // Not all error, not all stop → falls through to first state
@@ -238,13 +246,15 @@ final class PublisherManagerTests: XCTestCase {
         let delegate = MockPublisherManagerDelegate()
         await manager.setDelegate(delegate)
 
+        let info1 = LiveStreamInfo(url: "rtmp://a.com/1")
+        let info2 = LiveStreamInfo(url: "rtmp://b.com/2")
         let pub1 = MockPublisher()
         let pub2 = MockPublisher()
-        await manager.add(publisher: pub1, for: LiveStreamInfo(url: "rtmp://a.com/1"))
-        await manager.add(publisher: pub2, for: LiveStreamInfo(url: "rtmp://b.com/2"))
+        await manager.add(publisher: pub1, for: info1)
+        await manager.add(publisher: pub2, for: info2)
 
-        await manager.handleBufferStatus(from: "rtmp://a.com/1", status: .increase)
-        await manager.handleBufferStatus(from: "rtmp://b.com/2", status: .decline)
+        await manager.handleBufferStatus(from: info1.id, status: .increase)
+        await manager.handleBufferStatus(from: info2.id, status: .decline)
 
         XCTAssertEqual(delegate.aggregatedBufferStatuses.last, .increase)
     }
@@ -254,13 +264,15 @@ final class PublisherManagerTests: XCTestCase {
         let delegate = MockPublisherManagerDelegate()
         await manager.setDelegate(delegate)
 
+        let info1 = LiveStreamInfo(url: "rtmp://a.com/1")
+        let info2 = LiveStreamInfo(url: "rtmp://b.com/2")
         let pub1 = MockPublisher()
         let pub2 = MockPublisher()
-        await manager.add(publisher: pub1, for: LiveStreamInfo(url: "rtmp://a.com/1"))
-        await manager.add(publisher: pub2, for: LiveStreamInfo(url: "rtmp://b.com/2"))
+        await manager.add(publisher: pub1, for: info1)
+        await manager.add(publisher: pub2, for: info2)
 
-        await manager.handleBufferStatus(from: "rtmp://a.com/1", status: .decline)
-        await manager.handleBufferStatus(from: "rtmp://b.com/2", status: .decline)
+        await manager.handleBufferStatus(from: info1.id, status: .decline)
+        await manager.handleBufferStatus(from: info2.id, status: .decline)
 
         XCTAssertEqual(delegate.aggregatedBufferStatuses.last, .decline)
     }
@@ -270,13 +282,15 @@ final class PublisherManagerTests: XCTestCase {
         let delegate = MockPublisherManagerDelegate()
         await manager.setDelegate(delegate)
 
+        let info1 = LiveStreamInfo(url: "rtmp://a.com/1")
+        let info2 = LiveStreamInfo(url: "rtmp://b.com/2")
         let pub1 = MockPublisher()
         let pub2 = MockPublisher()
-        await manager.add(publisher: pub1, for: LiveStreamInfo(url: "rtmp://a.com/1"))
-        await manager.add(publisher: pub2, for: LiveStreamInfo(url: "rtmp://b.com/2"))
+        await manager.add(publisher: pub1, for: info1)
+        await manager.add(publisher: pub2, for: info2)
 
         // Only one of two publishers reports decline — not all decline, no increase → no callback
-        await manager.handleBufferStatus(from: "rtmp://a.com/1", status: .decline)
+        await manager.handleBufferStatus(from: info1.id, status: .decline)
 
         XCTAssertTrue(delegate.aggregatedBufferStatuses.isEmpty)
     }
@@ -289,13 +303,13 @@ final class PublisherManagerTests: XCTestCase {
         await manager.setDelegate(delegate)
 
         let pub = MockPublisher()
-        let url = "rtmp://example.com/live/test"
-        await manager.add(publisher: pub, for: LiveStreamInfo(url: url))
+        let info = LiveStreamInfo(url: "rtmp://example.com/live/test")
+        await manager.add(publisher: pub, for: info)
 
-        await manager.handleStateChange(from: url, state: .start)
+        await manager.handleStateChange(from: info.id, state: .start)
 
         XCTAssertEqual(delegate.stateChanges.count, 1)
-        XCTAssertEqual(delegate.stateChanges.first?.url, url)
+        XCTAssertEqual(delegate.stateChanges.first?.streamInfo.url, info.url)
         XCTAssertEqual(delegate.stateChanges.first?.state, .start)
     }
 
@@ -305,13 +319,13 @@ final class PublisherManagerTests: XCTestCase {
         await manager.setDelegate(delegate)
 
         let pub = MockPublisher()
-        let url = "rtmp://example.com/live/test"
-        await manager.add(publisher: pub, for: LiveStreamInfo(url: url))
+        let info = LiveStreamInfo(url: "rtmp://example.com/live/test")
+        await manager.add(publisher: pub, for: info)
 
-        await manager.handleError(from: url, error: .reconnectTimeOut)
+        await manager.handleError(from: info.id, error: .reconnectTimeOut)
 
         XCTAssertEqual(delegate.errors.count, 1)
-        XCTAssertEqual(delegate.errors.first?.url, url)
+        XCTAssertEqual(delegate.errors.first?.streamInfo.url, info.url)
         XCTAssertEqual(delegate.errors.first?.code, .reconnectTimeOut)
     }
 
@@ -320,24 +334,24 @@ final class PublisherManagerTests: XCTestCase {
         let delegate = MockPublisherManagerDelegate()
         await manager.setDelegate(delegate)
 
-        let url1 = "rtmp://youtube.com/live/key"
-        let url2 = "rtmp://twitch.tv/live/key"
+        let info1 = LiveStreamInfo(url: "rtmp://youtube.com/live/key")
+        let info2 = LiveStreamInfo(url: "rtmp://twitch.tv/live/key")
         let pub1 = MockPublisher()
         let pub2 = MockPublisher()
-        await manager.add(publisher: pub1, for: LiveStreamInfo(url: url1))
-        await manager.add(publisher: pub2, for: LiveStreamInfo(url: url2))
+        await manager.add(publisher: pub1, for: info1)
+        await manager.add(publisher: pub2, for: info2)
 
-        await manager.handleStateChange(from: url1, state: .start)
-        await manager.handleStateChange(from: url2, state: .error)
+        await manager.handleStateChange(from: info1.id, state: .start)
+        await manager.handleStateChange(from: info2.id, state: .error)
 
         // pub1 started → aggregated = .start
         let state = await manager.aggregatedState
         XCTAssertEqual(state, .start)
 
-        // Two separate delegate calls, one per url
+        // Two separate delegate calls, one per stream
         XCTAssertEqual(delegate.stateChanges.count, 2)
-        let urls = delegate.stateChanges.map { $0.url }
-        XCTAssertTrue(urls.contains(url1))
-        XCTAssertTrue(urls.contains(url2))
+        let urls = delegate.stateChanges.map { $0.streamInfo.url }
+        XCTAssertTrue(urls.contains(info1.url))
+        XCTAssertTrue(urls.contains(info2.url))
     }
 }

--- a/Tests/HPLiveKitTests/PublisherManagerTests.swift
+++ b/Tests/HPLiveKitTests/PublisherManagerTests.swift
@@ -1,0 +1,343 @@
+//
+//  PublisherManagerTests.swift
+//  HPLiveKitTests
+//
+
+import XCTest
+@testable import HPLiveKit
+
+// MARK: - Mock Publisher
+
+actor MockPublisher: Publisher {
+    private(set) var startCallCount = 0
+    private(set) var stopCallCount = 0
+    private(set) var receivedFrames: [any Frame] = []
+    private weak var delegate: PublisherDelegate?
+
+    func setDelegate(delegate: PublisherDelegate?) async {
+        self.delegate = delegate
+    }
+
+    func start() async {
+        startCallCount += 1
+    }
+
+    func stop() async {
+        stopCallCount += 1
+    }
+
+    func send(frame: any Frame) async {
+        receivedFrames.append(frame)
+    }
+
+    // Simulate state change notification to the manager via delegate
+    func simulateStateChange(_ state: LiveState) {
+        delegate?.publisher(publisher: self, publishStatus: state)
+    }
+
+    func simulateBufferStatus(_ status: BufferState) {
+        delegate?.publisher(publisher: self, bufferStatus: status)
+    }
+
+    func simulateError(_ code: LiveSocketErrorCode) {
+        delegate?.publisher(publisher: self, errorCode: code)
+    }
+}
+
+// MARK: - Mock Delegate
+
+final class MockPublisherManagerDelegate: PublisherManagerDelegate, @unchecked Sendable {
+    var aggregatedBufferStatuses: [BufferState] = []
+    var stateChanges: [(url: String, state: LiveState)] = []
+    var errors: [(url: String, code: LiveSocketErrorCode)] = []
+    var debugInfos: [(url: String, info: LiveDebug)] = []
+
+    func publisherManager(_ manager: PublisherManager, aggregatedBufferStatus: BufferState) {
+        aggregatedBufferStatuses.append(aggregatedBufferStatus)
+    }
+
+    func publisherManager(_ manager: PublisherManager, url: String, stateDidChange state: LiveState) {
+        stateChanges.append((url: url, state: state))
+    }
+
+    func publisherManager(_ manager: PublisherManager, url: String, errorCode: LiveSocketErrorCode) {
+        errors.append((url: url, code: errorCode))
+    }
+
+    func publisherManager(_ manager: PublisherManager, url: String, debugInfo: LiveDebug) {
+        debugInfos.append((url: url, info: debugInfo))
+    }
+}
+
+// MARK: - Minimal Frame for testing
+
+struct TestFrame: Frame {
+    var timestamp: UInt64
+    var data: Data?
+    var header: Data?
+}
+
+// MARK: - Tests
+
+final class PublisherManagerTests: XCTestCase {
+
+    // MARK: - isEmpty
+
+    func testEmptyOnInit() async {
+        let manager = PublisherManager()
+        let empty = await manager.isEmpty
+        XCTAssertTrue(empty)
+    }
+
+    func testNotEmptyAfterAdd() async {
+        let manager = PublisherManager()
+        let publisher = MockPublisher()
+        let info = LiveStreamInfo(url: "rtmp://example.com/live/stream1")
+        await manager.add(publisher: publisher, for: info)
+        let empty = await manager.isEmpty
+        XCTAssertFalse(empty)
+    }
+
+    func testEmptyAfterRemoveAll() async {
+        let manager = PublisherManager()
+        let publisher = MockPublisher()
+        let info = LiveStreamInfo(url: "rtmp://example.com/live/stream1")
+        await manager.add(publisher: publisher, for: info)
+        await manager.removeAll()
+        let empty = await manager.isEmpty
+        XCTAssertTrue(empty)
+    }
+
+    // MARK: - startAll / stopAll
+
+    func testStartAllCallsStartOnEachPublisher() async {
+        let manager = PublisherManager()
+        let pub1 = MockPublisher()
+        let pub2 = MockPublisher()
+        await manager.add(publisher: pub1, for: LiveStreamInfo(url: "rtmp://a.com/1"))
+        await manager.add(publisher: pub2, for: LiveStreamInfo(url: "rtmp://b.com/2"))
+
+        await manager.startAll()
+
+        let count1 = await pub1.startCallCount
+        let count2 = await pub2.startCallCount
+        XCTAssertEqual(count1, 1)
+        XCTAssertEqual(count2, 1)
+    }
+
+    func testStopAllCallsStopOnEachPublisher() async {
+        let manager = PublisherManager()
+        let pub1 = MockPublisher()
+        let pub2 = MockPublisher()
+        await manager.add(publisher: pub1, for: LiveStreamInfo(url: "rtmp://a.com/1"))
+        await manager.add(publisher: pub2, for: LiveStreamInfo(url: "rtmp://b.com/2"))
+
+        await manager.stopAll()
+
+        let count1 = await pub1.stopCallCount
+        let count2 = await pub2.stopCallCount
+        XCTAssertEqual(count1, 1)
+        XCTAssertEqual(count2, 1)
+    }
+
+    // MARK: - Frame fan-out
+
+    func testSendFrameFanOutToAllPublishers() async {
+        let manager = PublisherManager()
+        let pub1 = MockPublisher()
+        let pub2 = MockPublisher()
+        let pub3 = MockPublisher()
+        await manager.add(publisher: pub1, for: LiveStreamInfo(url: "rtmp://a.com/1"))
+        await manager.add(publisher: pub2, for: LiveStreamInfo(url: "rtmp://b.com/2"))
+        await manager.add(publisher: pub3, for: LiveStreamInfo(url: "rtmp://c.com/3"))
+
+        let frame = TestFrame(timestamp: 1000, data: Data([0x01, 0x02]))
+        await manager.send(frame: frame)
+
+        let frames1 = await pub1.receivedFrames
+        let frames2 = await pub2.receivedFrames
+        let frames3 = await pub3.receivedFrames
+        XCTAssertEqual(frames1.count, 1)
+        XCTAssertEqual(frames2.count, 1)
+        XCTAssertEqual(frames3.count, 1)
+    }
+
+    // MARK: - aggregatedState
+
+    func testAggregatedStateEmptyIsReady() async {
+        let manager = PublisherManager()
+        let state = await manager.aggregatedState
+        XCTAssertEqual(state, .ready)
+    }
+
+    func testAggregatedStateAnyStartWins() async {
+        let manager = PublisherManager()
+        let delegate = MockPublisherManagerDelegate()
+        await manager.setDelegate(delegate)
+
+        let pub1 = MockPublisher()
+        let pub2 = MockPublisher()
+        await manager.add(publisher: pub1, for: LiveStreamInfo(url: "rtmp://a.com/1"))
+        await manager.add(publisher: pub2, for: LiveStreamInfo(url: "rtmp://b.com/2"))
+
+        // Trigger state changes via delegate bridge
+        await manager.handleStateChange(from: "rtmp://a.com/1", state: .start)
+        await manager.handleStateChange(from: "rtmp://b.com/2", state: .stop)
+
+        let state = await manager.aggregatedState
+        XCTAssertEqual(state, .start)
+    }
+
+    func testAggregatedStateAllStopIsStop() async {
+        let manager = PublisherManager()
+        let pub1 = MockPublisher()
+        let pub2 = MockPublisher()
+        await manager.add(publisher: pub1, for: LiveStreamInfo(url: "rtmp://a.com/1"))
+        await manager.add(publisher: pub2, for: LiveStreamInfo(url: "rtmp://b.com/2"))
+
+        await manager.handleStateChange(from: "rtmp://a.com/1", state: .stop)
+        await manager.handleStateChange(from: "rtmp://b.com/2", state: .stop)
+
+        let state = await manager.aggregatedState
+        XCTAssertEqual(state, .stop)
+    }
+
+    func testAggregatedStateAllErrorIsError() async {
+        let manager = PublisherManager()
+        let pub1 = MockPublisher()
+        let pub2 = MockPublisher()
+        await manager.add(publisher: pub1, for: LiveStreamInfo(url: "rtmp://a.com/1"))
+        await manager.add(publisher: pub2, for: LiveStreamInfo(url: "rtmp://b.com/2"))
+
+        await manager.handleStateChange(from: "rtmp://a.com/1", state: .error)
+        await manager.handleStateChange(from: "rtmp://b.com/2", state: .error)
+
+        let state = await manager.aggregatedState
+        XCTAssertEqual(state, .error)
+    }
+
+    func testAggregatedStateMixedErrorAndStopIsNotError() async {
+        let manager = PublisherManager()
+        let pub1 = MockPublisher()
+        let pub2 = MockPublisher()
+        await manager.add(publisher: pub1, for: LiveStreamInfo(url: "rtmp://a.com/1"))
+        await manager.add(publisher: pub2, for: LiveStreamInfo(url: "rtmp://b.com/2"))
+
+        await manager.handleStateChange(from: "rtmp://a.com/1", state: .error)
+        await manager.handleStateChange(from: "rtmp://b.com/2", state: .stop)
+
+        let state = await manager.aggregatedState
+        // Not all error, not all stop → falls through to first state
+        XCTAssertNotEqual(state, .start)
+    }
+
+    // MARK: - Buffer status aggregation (most conservative signal wins)
+
+    func testBufferStatusAnyIncreaseDominates() async {
+        let manager = PublisherManager()
+        let delegate = MockPublisherManagerDelegate()
+        await manager.setDelegate(delegate)
+
+        let pub1 = MockPublisher()
+        let pub2 = MockPublisher()
+        await manager.add(publisher: pub1, for: LiveStreamInfo(url: "rtmp://a.com/1"))
+        await manager.add(publisher: pub2, for: LiveStreamInfo(url: "rtmp://b.com/2"))
+
+        await manager.handleBufferStatus(from: "rtmp://a.com/1", status: .increase)
+        await manager.handleBufferStatus(from: "rtmp://b.com/2", status: .decline)
+
+        XCTAssertEqual(delegate.aggregatedBufferStatuses.last, .increase)
+    }
+
+    func testBufferStatusAllDeclineTriggerDecline() async {
+        let manager = PublisherManager()
+        let delegate = MockPublisherManagerDelegate()
+        await manager.setDelegate(delegate)
+
+        let pub1 = MockPublisher()
+        let pub2 = MockPublisher()
+        await manager.add(publisher: pub1, for: LiveStreamInfo(url: "rtmp://a.com/1"))
+        await manager.add(publisher: pub2, for: LiveStreamInfo(url: "rtmp://b.com/2"))
+
+        await manager.handleBufferStatus(from: "rtmp://a.com/1", status: .decline)
+        await manager.handleBufferStatus(from: "rtmp://b.com/2", status: .decline)
+
+        XCTAssertEqual(delegate.aggregatedBufferStatuses.last, .decline)
+    }
+
+    func testBufferStatusPartialDeclineNoCallback() async {
+        let manager = PublisherManager()
+        let delegate = MockPublisherManagerDelegate()
+        await manager.setDelegate(delegate)
+
+        let pub1 = MockPublisher()
+        let pub2 = MockPublisher()
+        await manager.add(publisher: pub1, for: LiveStreamInfo(url: "rtmp://a.com/1"))
+        await manager.add(publisher: pub2, for: LiveStreamInfo(url: "rtmp://b.com/2"))
+
+        // Only one of two publishers reports decline — not all decline, no increase → no callback
+        await manager.handleBufferStatus(from: "rtmp://a.com/1", status: .decline)
+
+        XCTAssertTrue(delegate.aggregatedBufferStatuses.isEmpty)
+    }
+
+    // MARK: - Delegate callbacks
+
+    func testDelegateCalledWithCorrectUrlOnStateChange() async {
+        let manager = PublisherManager()
+        let delegate = MockPublisherManagerDelegate()
+        await manager.setDelegate(delegate)
+
+        let pub = MockPublisher()
+        let url = "rtmp://example.com/live/test"
+        await manager.add(publisher: pub, for: LiveStreamInfo(url: url))
+
+        await manager.handleStateChange(from: url, state: .start)
+
+        XCTAssertEqual(delegate.stateChanges.count, 1)
+        XCTAssertEqual(delegate.stateChanges.first?.url, url)
+        XCTAssertEqual(delegate.stateChanges.first?.state, .start)
+    }
+
+    func testDelegateCalledWithCorrectUrlOnError() async {
+        let manager = PublisherManager()
+        let delegate = MockPublisherManagerDelegate()
+        await manager.setDelegate(delegate)
+
+        let pub = MockPublisher()
+        let url = "rtmp://example.com/live/test"
+        await manager.add(publisher: pub, for: LiveStreamInfo(url: url))
+
+        await manager.handleError(from: url, error: .reconnectTimeOut)
+
+        XCTAssertEqual(delegate.errors.count, 1)
+        XCTAssertEqual(delegate.errors.first?.url, url)
+        XCTAssertEqual(delegate.errors.first?.code, .reconnectTimeOut)
+    }
+
+    func testMultiplePublishersIndependentStateTracking() async {
+        let manager = PublisherManager()
+        let delegate = MockPublisherManagerDelegate()
+        await manager.setDelegate(delegate)
+
+        let url1 = "rtmp://youtube.com/live/key"
+        let url2 = "rtmp://twitch.tv/live/key"
+        let pub1 = MockPublisher()
+        let pub2 = MockPublisher()
+        await manager.add(publisher: pub1, for: LiveStreamInfo(url: url1))
+        await manager.add(publisher: pub2, for: LiveStreamInfo(url: url2))
+
+        await manager.handleStateChange(from: url1, state: .start)
+        await manager.handleStateChange(from: url2, state: .error)
+
+        // pub1 started → aggregated = .start
+        let state = await manager.aggregatedState
+        XCTAssertEqual(state, .start)
+
+        // Two separate delegate calls, one per url
+        XCTAssertEqual(delegate.stateChanges.count, 2)
+        let urls = delegate.stateChanges.map { $0.url }
+        XCTAssertTrue(urls.contains(url1))
+        XCTAssertTrue(urls.contains(url2))
+    }
+}


### PR DESCRIPTION
## Summary

- Add `PublisherManager` actor to fan-out encoded frames to multiple `RtmpPublisher` instances simultaneously (e.g. YouTube + Twitch + Bilibili)
- Each publisher keeps its own independent `StreamingBuffer`, reconnect logic, and RTMP connection — no changes to existing publisher internals
- `startLive(streamInfo:)` remains fully backward-compatible; new `startLive(streamInfos:)` accepts multiple destinations
- Adaptive bitrate uses most-conservative-wins strategy: any publisher reporting buffer increase triggers bitrate decrease; bitrate only increases when **all** publishers report decline
- `LiveSessionDelegate` gains three optional per-URL callbacks (`stateDidChange`, `errorCode`, `debugInfo`) with default empty implementations — existing delegates need no changes
- Fix: buffer `.decline` aggregation previously fired when only a subset of publishers reported decline (dict `allSatisfy` on partial entries); now requires all registered publishers to have reported

## Architecture

```
Encoders → LiveSession.frameStream
                    │
             PublisherManager (actor)
            /        │         \
     Publisher_1  Publisher_2  Publisher_N
     (YouTube)   (Twitch)    (Bilibili)
```

## Test plan

- [ ] All 32 unit tests pass (`PublisherManagerTests`: 17 new cases)
- [ ] `isEmpty` / `add` / `removeAll` lifecycle
- [ ] `startAll` / `stopAll` call each publisher exactly once
- [ ] `send(frame:)` fan-out reaches all publishers
- [ ] `aggregatedState`: any `.start` wins; all `.error` / all `.stop` required for those states
- [ ] Buffer status: `.increase` dominates; `.decline` only fires when all publishers report it; partial decline triggers no callback
- [ ] Per-URL delegate callbacks carry correct url and state
- [ ] Multi-publisher independent state tracking (one `.start` + one `.error` → aggregated `.start`)