### PR TITLE
fix: resolve critical bugs, thread safety, and memory issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,13 +1,11 @@
 name: CI
 
-on: [push]
-
-env:
-  DEVELOPER_DIR: /Applications/Xcode_26.0.1.app
+on:
+  push:
+  pull_request:
 
 jobs:
   build:
-
     runs-on: macos-latest
 
     steps:
@@ -28,8 +26,11 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-spm-
 
-    - name: Resolve SPM dependencies
+    - name: Test HPLiveKitCore (macOS)
+      run: swift test --filter HPLiveKitCoreTests
+
+    - name: Resolve SPM dependencies (Example)
       run: xcodebuild -resolvePackageDependencies -project Example/HPLiveKit.xcodeproj -scheme HPLiveKit-Example
 
-    - name: Build
+    - name: Build Example (iOS Simulator)
       run: xcodebuild -project Example/HPLiveKit.xcodeproj -scheme HPLiveKit-Example -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -configuration Debug build

--- a/.swiftpm/xcode/xcshareddata/xcschemes/HPLiveKit-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/HPLiveKit-Package.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "HPLiveKitCore"
+               BuildableName = "HPLiveKitCore"
+               BlueprintName = "HPLiveKitCore"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -28,6 +42,28 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "HPLiveKitCoreTests"
+               BuildableName = "HPLiveKitCoreTests"
+               BlueprintName = "HPLiveKitCoreTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "HPLiveKitTests"
+               BuildableName = "HPLiveKitTests"
+               BlueprintName = "HPLiveKitTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Sources/HPLiveKit/Capture/CaptureManager.swift
+++ b/Sources/HPLiveKit/Capture/CaptureManager.swift
@@ -27,6 +27,7 @@ public class CaptureManager: NSObject {
   weak var delegate: CaptureManagerDelegate?
   
   // TODO: remove preview from CaptureManager
+  @MainActor
   public var preview: UIView? {
     get {
       videoCapture.preview

--- a/Sources/HPLiveKit/Capture/CaptureManager.swift
+++ b/Sources/HPLiveKit/Capture/CaptureManager.swift
@@ -44,11 +44,7 @@ public class CaptureManager: NSObject {
   
   public var captureDevicePositionFront: Bool = true {
     didSet {
-      if videoCapture.captureDevicePosition == .front {
-        videoCapture.captureDevicePosition = .back
-      } else {
-        videoCapture.captureDevicePosition = .front
-      }
+      videoCapture.captureDevicePosition = captureDevicePositionFront ? .front : .back
     }
   }
 

--- a/Sources/HPLiveKit/Capture/LiveAudioCapture.swift
+++ b/Sources/HPLiveKit/Capture/LiveAudioCapture.swift
@@ -93,11 +93,10 @@ class LiveAudioCapture: NSObject {
   }
   
   deinit {
-    // Fix: Use async instead of sync to avoid deadlock
-    // In deinit, sync will wait for the queue, but the setter is async,
-    // causing a deadlock. Using async or direct stopRunning() is safe.
-    taskQueue.async { [weak self] in
-      self?.captureSession.stopRunning()
+    // Capture captureSession directly (not self) so the async block executes after deinit
+    let session = captureSession
+    taskQueue.async {
+      session.stopRunning()
     }
   }
   
@@ -115,10 +114,12 @@ extension LiveAudioCapture {
   
   private func configureAudio() {
     guard let audioDevice = AVCaptureDevice.default(for: .audio) else {
-      fatalError("[HPLiveKit] Can not found audio device!")
+      print("[HPLiveKit] Warning: Audio device not found. Audio capture will not work.")
+      return
     }
-    guard let audioDeviceInput = try? AVCaptureDeviceInput.init(device: audioDevice) else {
-      fatalError("[HPLiveKit] Init audio CaptureDeviceInput failed!")
+    guard let audioDeviceInput = try? AVCaptureDeviceInput(device: audioDevice) else {
+      print("[HPLiveKit] Warning: Failed to create audio capture input.")
+      return
     }
     
     if captureSession.canAddInput(audioDeviceInput) {

--- a/Sources/HPLiveKit/Capture/LiveVideoCapture.swift
+++ b/Sources/HPLiveKit/Capture/LiveVideoCapture.swift
@@ -88,25 +88,25 @@ class LiveVideoCapture: NSObject {
     videoConnection?.videoOrientation = .portrait
   }
   
-  private func configurePreview() {
-    let previewVideoView = PreviewView(frame: CGRect.zero)
-    previewVideoView.videoPreviewLayer?.session = captureSession
-    
-    self.previewVideoView = previewVideoView
-  }
-  
+  @MainActor
   public var preview: UIView? {
     get {
       return previewVideoView?.superview
     }
     set {
+      if previewVideoView == nil {
+        let view = PreviewView(frame: .zero)
+        view.videoPreviewLayer?.session = captureSession
+        previewVideoView = view
+      }
+
       if previewVideoView?.superview != nil {
         previewVideoView?.removeFromSuperview()
       }
-      
+
       if let perview = newValue, let previewVideoView = previewVideoView {
         perview.insertSubview(previewVideoView, at: 0)
-        
+
         previewVideoView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
           perview.topAnchor.constraint(equalTo: previewVideoView.topAnchor),
@@ -173,7 +173,6 @@ class LiveVideoCapture: NSObject {
     
     configureNotifications()
     configureVideo()
-    configurePreview()
   }
   
   deinit {
@@ -200,7 +199,9 @@ class LiveVideoCapture: NSObject {
       previewToClean?.removeFromSuperview()
     }
     
-    UIApplication.shared.isIdleTimerDisabled = false
+    DispatchQueue.main.async {
+      UIApplication.shared.isIdleTimerDisabled = false
+    }
   }
   
   /// Start capturing video

--- a/Sources/HPLiveKit/Capture/LiveVideoCapture.swift
+++ b/Sources/HPLiveKit/Capture/LiveVideoCapture.swift
@@ -60,10 +60,12 @@ class LiveVideoCapture: NSObject {
   
   private func configureVideo() {
     guard let videoDevice = frontVideoDevice else {
-      fatalError("[HPLiveKit] Can not found front video device!")
+      print("[HPLiveKit] Warning: Front video device not found. Camera capture will not work.")
+      return
     }
-    guard let videoInput = try? AVCaptureDeviceInput.init(device: videoDevice) else {
-      fatalError("[HPLiveKit] Init video CaptureDeviceInput failed!")
+    guard let videoInput = try? AVCaptureDeviceInput(device: videoDevice) else {
+      print("[HPLiveKit] Warning: Failed to create video capture input.")
+      return
     }
     
     if captureSession.canAddInput(videoInput) {
@@ -128,10 +130,12 @@ class LiveVideoCapture: NSObject {
       if newValue == .unspecified { return }
                   
       guard let videoDevice = newValue == .front ? frontVideoDevice : backVideoDevice else {
-        fatalError("[HPLiveKit] Can not found font video device!")
+        print("[HPLiveKit] Warning: Video device not found for position: \(String(describing: newValue))")
+        return
       }
-      guard let videoInput = try? AVCaptureDeviceInput.init(device: videoDevice) else {
-        fatalError("[HPLiveKit] Init video CaptureDeviceInput failed!")
+      guard let videoInput = try? AVCaptureDeviceInput(device: videoDevice) else {
+        print("[HPLiveKit] Warning: Failed to create video capture input.")
+        return
       }
       
       captureSession.beginConfiguration()

--- a/Sources/HPLiveKit/LiveSession.swift
+++ b/Sources/HPLiveKit/LiveSession.swift
@@ -153,6 +153,7 @@ public class LiveSession: NSObject, @unchecked Sendable {
     private let frameContinuation: AsyncStream<any Frame>.Continuation
     private var frameProcessingTask: Task<Void, Never>?
 
+    @MainActor
     public var preview: UIView? {
         get {
             capture?.preview

--- a/Sources/HPLiveKit/LiveSession.swift
+++ b/Sources/HPLiveKit/LiveSession.swift
@@ -110,20 +110,43 @@ public class LiveSession: NSObject, @unchecked Sendable {
     // Audio mixer (only for screenShare mode)
     private var audioMixer: AudioMixer?
 
+    // Lock protecting shared mutable state accessed from multiple threads/Tasks
+    private let stateLock = NSLock()
+
     // 调试信息 debug info
-    private var debugInfo: LiveDebug?
+    private var _debugInfo: LiveDebug?
+    private var debugInfo: LiveDebug? {
+        get { stateLock.withLock { _debugInfo } }
+        set { stateLock.withLock { _debugInfo = newValue } }
+    }
     // 是否开始上传  is publishing
-    private var uploading: Bool = false
+    private var _uploading: Bool = false
+    private var uploading: Bool {
+        get { stateLock.withLock { _uploading } }
+        set { stateLock.withLock { _uploading = newValue } }
+    }
     // 当前状态 current live stream state
-    private var state: LiveState?
+    private var _state: LiveState?
+    private var state: LiveState? {
+        get { stateLock.withLock { _state } }
+        set { stateLock.withLock { _state = newValue } }
+    }
     // 当前直播type current live type
     private var captureType: LiveCaptureType = LiveCaptureTypeMask.captureDefaultMask
     // 当前模式 (camera or screenShare)
     private let mode: LiveSessionMode
     /// 当前是否采集到了音频
-    private var hasCapturedAudio: Bool = false
+    private var _hasCapturedAudio: Bool = false
+    private var hasCapturedAudio: Bool {
+        get { stateLock.withLock { _hasCapturedAudio } }
+        set { stateLock.withLock { _hasCapturedAudio = newValue } }
+    }
     /// 当前是否采集到了关键帧
-    private var hasCapturedKeyFrame: Bool = false
+    private var _hasCapturedKeyFrame: Bool = false
+    private var hasCapturedKeyFrame: Bool {
+        get { stateLock.withLock { _hasCapturedKeyFrame } }
+        set { stateLock.withLock { _hasCapturedKeyFrame = newValue } }
+    }
 
     // Frame processing with AsyncStream to ensure sequential order
     private let frameStream: AsyncStream<any Frame>
@@ -257,6 +280,15 @@ public class LiveSession: NSObject, @unchecked Sendable {
         audioEncoderTask?.cancel()
         videoEncoderTask?.cancel()
         mixerTask?.cancel()
+
+        // Release encoder system resources (VTCompressionSession / AudioConverter)
+        // Capture by value to avoid deinit-from-actor constraints
+        let ae = audioEncoder
+        let ve = videoEncoder
+        Task {
+            await ae.stop()
+            await ve.stop()
+        }
     }
 
     public func startLive(streamInfo: LiveStreamInfo) {
@@ -397,7 +429,7 @@ private extension LiveSession {
                 if let pcmData = AudioSampleBufferUtils.extractPCMData(from: mixedBufferBox.samplebuffer),
                    let format = AudioSampleBufferUtils.extractFormat(from: mixedBufferBox.samplebuffer) {
                     let rms = AudioSampleBufferUtils.calculateRMS(pcmData: pcmData, bitsPerChannel: Int(format.mBitsPerChannel))
-                    Self.logger.info("[DIAGNOSTIC] SCENARIO-B (AudioMixer) ENCODE INPUT: ts=\(timestamp.seconds)s, size=\(pcmData.count), RMS=\(String(format: "%.4f", rms)), format=\(format.mSampleRate)Hz/\(format.mChannelsPerFrame)ch/\(format.mBitsPerChannel)bit")
+                    Self.logger.debug("[DIAGNOSTIC] SCENARIO-B (AudioMixer) ENCODE INPUT: ts=\(timestamp.seconds)s, size=\(pcmData.count), RMS=\(String(format: "%.4f", rms)), format=\(format.mSampleRate)Hz/\(format.mChannelsPerFrame)ch/\(format.mBitsPerChannel)bit")
                 }
 
                 // Mixed audio already has normalized timestamp from mixer

--- a/Sources/HPLiveKitCore/Coder/AudioMixer.swift
+++ b/Sources/HPLiveKitCore/Coder/AudioMixer.swift
@@ -302,41 +302,37 @@ package actor AudioMixer {
       return app
     }
 
+    // Copy to [Int16] arrays: Sendable value types not tied to any Data region,
+    // so they can be safely captured inside withUnsafeMutableBytes under Swift 6.
+    let appSamples: [Int16] = app.withUnsafeBytes { Array($0.bindMemory(to: Int16.self)) }
+    let micSamples: [Int16] = mic.withUnsafeBytes { Array($0.bindMemory(to: Int16.self)) }
+
+    var appFloat = [Float](repeating: 0, count: sampleCount)
+    var micFloat = [Float](repeating: 0, count: sampleCount)
+    var mixedFloat = [Float](repeating: 0, count: sampleCount)
+
+    vDSP_vflt16(appSamples, 1, &appFloat, 1, vDSP_Length(sampleCount))
+    vDSP_vflt16(micSamples, 1, &micFloat, 1, vDSP_Length(sampleCount))
+
+    var effectiveAppGain = appVolume
+    var effectiveMicGain = micVolume
+
+    let totalGain = appVolume + micVolume
+    if totalGain > 1.5 {
+      Self.logger.warning("Total gain (\(String(format: "%.2f", totalGain))) is high. Relying on soft limiter to prevent clipping.")
+    }
+
+    vDSP_vsmul(appFloat, 1, &effectiveAppGain, &appFloat, 1, vDSP_Length(sampleCount))
+    vDSP_vsmul(micFloat, 1, &effectiveMicGain, &micFloat, 1, vDSP_Length(sampleCount))
+    vDSP_vadd(appFloat, 1, micFloat, 1, &mixedFloat, 1, vDSP_Length(sampleCount))
+
+    var minValue = Float(Int16.min)
+    var maxValue = Float(Int16.max)
+    vDSP_vclip(mixedFloat, 1, &minValue, &maxValue, &mixedFloat, 1, vDSP_Length(sampleCount))
+
     var mixedData = Data(count: sampleCount * 2)
-
-    app.withUnsafeBytes { appBytes in
-      mic.withUnsafeBytes { micBytes in
-        mixedData.withUnsafeMutableBytes { mixedBytes in
-          let appSamples = appBytes.bindMemory(to: Int16.self)
-          let micSamples = micBytes.bindMemory(to: Int16.self)
-          let mixedSamples = mixedBytes.bindMemory(to: Int16.self)
-
-          var appFloat = [Float](repeating: 0, count: sampleCount)
-          var micFloat = [Float](repeating: 0, count: sampleCount)
-          var mixedFloat = [Float](repeating: 0, count: sampleCount)
-
-          vDSP_vflt16(appSamples.baseAddress!, 1, &appFloat, 1, vDSP_Length(sampleCount))
-          vDSP_vflt16(micSamples.baseAddress!, 1, &micFloat, 1, vDSP_Length(sampleCount))
-
-          var effectiveAppGain = appVolume
-          var effectiveMicGain = micVolume
-
-          let totalGain = appVolume + micVolume
-          if totalGain > 1.5 {
-            Self.logger.warning("Total gain (\(String(format: "%.2f", totalGain))) is high. Relying on soft limiter to prevent clipping.")
-          }
-
-          vDSP_vsmul(appFloat, 1, &effectiveAppGain, &appFloat, 1, vDSP_Length(sampleCount))
-          vDSP_vsmul(micFloat, 1, &effectiveMicGain, &micFloat, 1, vDSP_Length(sampleCount))
-          vDSP_vadd(appFloat, 1, micFloat, 1, &mixedFloat, 1, vDSP_Length(sampleCount))
-
-          var minValue = Float(Int16.min)
-          var maxValue = Float(Int16.max)
-          vDSP_vclip(mixedFloat, 1, &minValue, &maxValue, &mixedFloat, 1, vDSP_Length(sampleCount))
-
-          vDSP_vfix16(mixedFloat, 1, mixedSamples.baseAddress!, 1, vDSP_Length(sampleCount))
-        }
-      }
+    mixedData.withUnsafeMutableBytes { mixedBytes in
+      vDSP_vfix16(mixedFloat, 1, mixedBytes.bindMemory(to: Int16.self).baseAddress!, 1, vDSP_Length(sampleCount))
     }
 
     return mixedData

--- a/Sources/HPLiveKitCore/Coder/AudioResampler.swift
+++ b/Sources/HPLiveKitCore/Coder/AudioResampler.swift
@@ -178,101 +178,88 @@ package actor AudioResampler {
     let outputBytesPerFrame = Int(targetBitsPerChannel / 8 * targetChannels)
     let outputSize = Int(Double(targetFrames * outputBytesPerFrame) * 1.5)
 
-    var outputData = Data(count: outputSize)
+    // Use independently allocated buffers (not borrowed from any Data) so that pointers
+    // can be used freely across closure boundaries without Swift 6 region isolation errors.
+    let inputCount = audioData.count
+    let inputBuffer = UnsafeMutableRawPointer.allocate(byteCount: inputCount, alignment: MemoryLayout<UInt8>.alignment)
+    defer { inputBuffer.deallocate() }
+    audioData.copyBytes(to: inputBuffer.assumingMemoryBound(to: UInt8.self), count: inputCount)
 
-    let inputDataCopy = audioData
-    let sourceFormatCopy = sourceFormat
+    let outputBuffer = UnsafeMutableRawPointer.allocate(byteCount: outputSize, alignment: MemoryLayout<UInt8>.alignment)
+    defer { outputBuffer.deallocate() }
 
-    // Callback supports multiple reads - AudioConverter may request data in chunks
-    let result: (status: OSStatus, actualSize: Int) = inputDataCopy.withUnsafeBytes { inputBytes in
-      outputData.withUnsafeMutableBytes { outputBytes in
-        guard let inputBaseAddress = inputBytes.baseAddress,
-              let outputBaseAddress = outputBytes.baseAddress else {
-          return (kAudioConverterErr_InvalidInputSize, 0)
-        }
-
-        var outBufferList = AudioBufferList()
-        outBufferList.mNumberBuffers = 1
-        outBufferList.mBuffers.mNumberChannels = targetChannels
-        outBufferList.mBuffers.mDataByteSize = UInt32(outputSize)
-        outBufferList.mBuffers.mData = outputBaseAddress
-
-        var ioOutputDataPacketSize = UInt32(targetFrames)
-
-        // Track consumed frames to support multiple callback invocations
-        struct CallbackState {
-          let inputBaseAddress: UnsafeRawPointer
-          let inputDataSize: Int
-          let sourceFormat: AudioStreamBasicDescription
-          var consumedFrames: Int = 0
-          var callCount: Int = 0
-        }
-
-        var callbackState = CallbackState(
-          inputBaseAddress: inputBaseAddress,
-          inputDataSize: inputDataCopy.count,
-          sourceFormat: sourceFormatCopy
-        )
-
-        let status = withUnsafeMutablePointer(to: &callbackState) { statePtr in
-          AudioConverterFillComplexBuffer(
-            converter,
-            { (_, ioNumDataPackets, ioData, _, inUserData) -> OSStatus in
-              guard let userDataPtr = inUserData else {
-                return kAudioConverterErr_InvalidInputSize
-              }
-
-              let state = userDataPtr.assumingMemoryBound(to: CallbackState.self)
-              state.pointee.callCount += 1
-
-              let bytesPerFrame = Int(state.pointee.sourceFormat.mBytesPerFrame)
-              let totalFrames = state.pointee.inputDataSize / bytesPerFrame
-              let remainingFrames = totalFrames - state.pointee.consumedFrames
-
-              if remainingFrames <= 0 {
-                ioNumDataPackets.pointee = 0
-                return noErr
-              }
-
-              let framesToProvide = min(remainingFrames, Int(ioNumDataPackets.pointee))
-              let bytesToProvide = framesToProvide * bytesPerFrame
-              let offsetBytes = state.pointee.consumedFrames * bytesPerFrame
-
-              var inBufferList = AudioBufferList()
-              inBufferList.mNumberBuffers = 1
-              inBufferList.mBuffers.mNumberChannels = state.pointee.sourceFormat.mChannelsPerFrame
-              inBufferList.mBuffers.mDataByteSize = UInt32(bytesToProvide)
-              inBufferList.mBuffers.mData = UnsafeMutableRawPointer(mutating: state.pointee.inputBaseAddress.advanced(by: offsetBytes))
-
-              ioData.pointee = inBufferList
-              ioNumDataPackets.pointee = UInt32(framesToProvide)
-
-              state.pointee.consumedFrames += framesToProvide
-
-              return noErr
-            },
-            statePtr,
-            &ioOutputDataPacketSize,
-            &outBufferList,
-            nil
-          )
-        }
-
-        let actualFramesWritten = Int(ioOutputDataPacketSize)
-        let actualBytesWritten = actualFramesWritten * outputBytesPerFrame
-
-        return (status, actualBytesWritten)
-      }
+    // Track consumed frames to support multiple callback invocations
+    struct CallbackState {
+      let inputBaseAddress: UnsafeMutableRawPointer
+      let inputDataSize: Int
+      let sourceFormat: AudioStreamBasicDescription
+      var consumedFrames: Int = 0
     }
 
-    guard result.status == noErr else {
-      Self.logger.error("AudioConverterFillComplexBuffer failed: \(result.status, privacy: .public)")
+    var callbackState = CallbackState(
+      inputBaseAddress: inputBuffer,
+      inputDataSize: inputCount,
+      sourceFormat: sourceFormat
+    )
+
+    var outBufferList = AudioBufferList()
+    outBufferList.mNumberBuffers = 1
+    outBufferList.mBuffers.mNumberChannels = targetChannels
+    outBufferList.mBuffers.mDataByteSize = UInt32(outputSize)
+    outBufferList.mBuffers.mData = outputBuffer
+
+    var ioOutputDataPacketSize = UInt32(targetFrames)
+
+    let status = withUnsafeMutablePointer(to: &callbackState) { statePtr in
+      AudioConverterFillComplexBuffer(
+        converter,
+        { (_, ioNumDataPackets, ioData, _, inUserData) -> OSStatus in
+          guard let userDataPtr = inUserData else {
+            return kAudioConverterErr_InvalidInputSize
+          }
+
+          let state = userDataPtr.assumingMemoryBound(to: CallbackState.self)
+
+          let bytesPerFrame = Int(state.pointee.sourceFormat.mBytesPerFrame)
+          let totalFrames = state.pointee.inputDataSize / bytesPerFrame
+          let remainingFrames = totalFrames - state.pointee.consumedFrames
+
+          if remainingFrames <= 0 {
+            ioNumDataPackets.pointee = 0
+            return noErr
+          }
+
+          let framesToProvide = min(remainingFrames, Int(ioNumDataPackets.pointee))
+          let bytesToProvide = framesToProvide * bytesPerFrame
+          let offsetBytes = state.pointee.consumedFrames * bytesPerFrame
+
+          var inBufferList = AudioBufferList()
+          inBufferList.mNumberBuffers = 1
+          inBufferList.mBuffers.mNumberChannels = state.pointee.sourceFormat.mChannelsPerFrame
+          inBufferList.mBuffers.mDataByteSize = UInt32(bytesToProvide)
+          inBufferList.mBuffers.mData = state.pointee.inputBaseAddress.advanced(by: offsetBytes)
+
+          ioData.pointee = inBufferList
+          ioNumDataPackets.pointee = UInt32(framesToProvide)
+
+          state.pointee.consumedFrames += framesToProvide
+
+          return noErr
+        },
+        statePtr,
+        &ioOutputDataPacketSize,
+        &outBufferList,
+        nil
+      )
+    }
+
+    guard status == noErr else {
+      Self.logger.error("AudioConverterFillComplexBuffer failed: \(status, privacy: .public)")
       return nil
     }
 
-    outputData.count = result.actualSize
-
-    return outputData
+    let actualBytesWritten = Int(ioOutputDataPacketSize) * outputBytesPerFrame
+    return Data(bytes: outputBuffer, count: actualBytesWritten)
   }
 
   private func createSampleBuffer(from data: Data, timestamp: CMTime) -> CMSampleBuffer? {

--- a/Sources/HPLiveKitCore/Coder/TimestampSynchronizer.swift
+++ b/Sources/HPLiveKitCore/Coder/TimestampSynchronizer.swift
@@ -10,77 +10,54 @@ import CoreMedia
 
 /// Synchronizes timestamps across audio and video frames
 /// Converts absolute timestamps to relative timestamps starting from 0
-package class TimestampSynchronizer {
+/// Thread-safe: recordIfNeeded/normalize/reset may be called from different threads
+package final class TimestampSynchronizer: @unchecked Sendable {
 
     // Unified base timestamp for audio/video synchronization
     // Set to the timestamp of the first frame (audio or video) that arrives
     private var baseTimestamp: UInt64?
+    private let lock = NSLock()
 
     package init() {}
 
     /// Record base timestamp from sample buffer if not yet set
-    /// Call this BEFORE encoding to ensure correct timestamp order
-    /// - Parameter sampleBuffer: The sample buffer to extract timestamp from
     package func recordIfNeeded(_ sampleBuffer: CMSampleBuffer) {
+        lock.lock()
+        defer { lock.unlock() }
         if baseTimestamp == nil {
             let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
             baseTimestamp = UInt64(CMTimeGetSeconds(pts) * 1000)
         }
     }
 
-    /// Normalize audio frame timestamp relative to base timestamp
-    /// Call this AFTER encoding to get normalized frame
-    /// - Parameter frame: Original audio frame with absolute timestamp
-    /// - Returns: New audio frame with normalized timestamp (relative to base)
     package func normalize(_ frame: AudioFrame) -> AudioFrame {
-        guard let base = baseTimestamp else {
-            // If baseTimestamp is not set, return original frame
-            // This should not happen in normal flow
-            return frame
-        }
+        lock.lock()
+        let base = baseTimestamp
+        lock.unlock()
 
-        // Prevent UInt64 underflow crash
-        let normalizedTimestamp = frame.timestamp >= base
-            ? frame.timestamp - base
-            : 0
-
-        return AudioFrame(
-            timestamp: normalizedTimestamp,
-            data: frame.data,
-            header: frame.header,
-            aacHeader: frame.aacHeader
-        )
+        guard let base else { return frame }
+        let ts = frame.timestamp >= base ? frame.timestamp - base : 0
+        return AudioFrame(timestamp: ts, data: frame.data, header: frame.header, aacHeader: frame.aacHeader)
     }
 
-    /// Normalize video frame timestamp relative to base timestamp
-    /// Call this AFTER encoding to get normalized frame
-    /// - Parameter frame: Original video frame with absolute timestamp
-    /// - Returns: New video frame with normalized timestamp (relative to base)
     package func normalize(_ frame: VideoFrame) -> VideoFrame {
-        guard let base = baseTimestamp else {
-            // If baseTimestamp is not set, return original frame
-            // This should not happen in normal flow
-            return frame
-        }
+        lock.lock()
+        let base = baseTimestamp
+        lock.unlock()
 
-        // Prevent UInt64 underflow crash
-        let normalizedTimestamp = frame.timestamp >= base
-            ? frame.timestamp - base
-            : 0
-
+        guard let base else { return frame }
+        let ts = frame.timestamp >= base ? frame.timestamp - base : 0
         return VideoFrame(
-            timestamp: normalizedTimestamp,
-            data: frame.data,
-            header: frame.header,
-            isKeyFrame: frame.isKeyFrame,
-            compositionTime: frame.compositionTime,
-            sps: frame.sps,
-            pps: frame.pps
+            timestamp: ts, data: frame.data, header: frame.header,
+            isKeyFrame: frame.isKeyFrame, compositionTime: frame.compositionTime,
+            sps: frame.sps, pps: frame.pps
         )
     }
 
     /// Reset base timestamp (call when starting a new stream)
     package func reset() {
+        lock.lock()
+        defer { lock.unlock() }
         baseTimestamp = nil
     }
 }

--- a/Sources/HPLiveKitCore/Objects/LiveDebug.swift
+++ b/Sources/HPLiveKitCore/Objects/LiveDebug.swift
@@ -9,37 +9,37 @@ import Foundation
 
 public struct LiveDebug: Sendable {
   /// Stream URLs
-  var uploadUrl: String?
+  public var uploadUrl: String?
   /// Uploaded resolution
-  var videoSize: CGSize?
+  public var videoSize: CGSize?
   /// Time elapsed since the last statistic, in milliseconds
-  var elapsedMilli: CGFloat = 0
+  public var elapsedMilli: CGFloat = 0
   /// Current timestamp, used for calculating data within 1 second
-  var currentTimeStamp: CGFloat = 0
+  public var currentTimeStamp: CGFloat = 0
   /// Total data size
-  var allDataSize: CGFloat = 0
+  public var allDataSize: CGFloat = 0
   /// Bandwidth per second
-  var bandwidthPerSec: CGFloat = 0
+  public var bandwidthPerSec: CGFloat = 0
   /// Last measured bandwidth
-  var currentBandwidth: CGFloat = 0
-  
+  public var currentBandwidth: CGFloat = 0
+
   /// Number of frames dropped
-  var dropFrameCount: Int = 0
+  public var dropFrameCount: Int = 0
   /// Total number of frames
-  var totalFrameCount: Int = 0
-  
+  public var totalFrameCount: Int = 0
+
   /// Number of audio captures per second
-  var capturedAudioCountPerSec: Int = 0
+  public var capturedAudioCountPerSec: Int = 0
   /// Number of video captures per second
-  var capturedVideoCountPerSec: Int = 0
-  
+  public var capturedVideoCountPerSec: Int = 0
+
   /// Last measured number of audio captures
-  var currentCapturedAudioCount: Int = 0
+  public var currentCapturedAudioCount: Int = 0
   /// Last measured number of video captures
-  var currentCapturedVideoCount: Int = 0
-  
+  public var currentCapturedVideoCount: Int = 0
+
   /// Number of unsent frames (representing current buffer waiting to be sent)
-  var unsendCount: Int = 0
+  public var unsendCount: Int = 0
 }
 
 extension LiveDebug: CustomStringConvertible {

--- a/Sources/HPLiveKitCore/Publish/RtmpPublisher.swift
+++ b/Sources/HPLiveKitCore/Publish/RtmpPublisher.swift
@@ -163,7 +163,7 @@ actor RtmpPublisher: Publisher {
         self.isConnected = false
         self.isConnecting = false
         self.isReconnecting = true
-        try await Task.sleep(nanoseconds: UInt64(reconnectInterval) * 1000000)
+        try await Task.sleep(nanoseconds: UInt64(reconnectInterval) * 1_000_000_000)
         await self._reconnect()
       } else if self.retryTimes4netWorkBreaken >= self.reconnectCount {
         self.delegate?.publisher(publisher: self, publishStatus: .error)
@@ -193,6 +193,8 @@ actor RtmpPublisher: Publisher {
     frameProcessingTask?.cancel()
     frameProcessingTask = nil
     frameContinuation.finish()
+
+    await buffer.stopTick()
 
     delegate?.publisher(publisher: self, publishStatus: .stop)
 
@@ -311,7 +313,7 @@ private extension RtmpPublisher {
       debugInfo.unsendCount = await buffer.list.count
     } else {
       debugInfo.currentBandwidth = debugInfo.bandwidthPerSec
-      debugInfo.currentCapturedAudioCount = debugInfo.currentCapturedAudioCount
+      debugInfo.currentCapturedAudioCount = debugInfo.capturedAudioCountPerSec
       debugInfo.currentCapturedVideoCount = debugInfo.capturedVideoCountPerSec
 
       delegate?.publisher(publisher: self, debugInfo: debugInfo)
@@ -427,9 +429,9 @@ extension RtmpPublisher: StreamingBufferDelegate {
 }
 
 
-extension ExpressibleByIntegerLiteral {
+extension FixedWidthInteger {
   var data: Data {
-    var value: Self = self
+    var value = self
     return Data(bytes: &value, count: MemoryLayout<Self>.size)
   }
 }

--- a/Sources/HPLiveKitCore/Publish/StreamingBuffer.swift
+++ b/Sources/HPLiveKitCore/Publish/StreamingBuffer.swift
@@ -36,21 +36,22 @@ actor StreamingBuffer {
   
   /** current frame buffer */
   private(set) var list: [any Frame] = .init()
-  
+
   /** buffer count max size */
   var maxCount: UInt = defaultSendBufferMaxCount
-  
+
   /** count of drop frames in last time */
   var lastDropFrames: Int = 0
-  
+
   private var sortList: [any Frame] = .init()
   private var thresholdList: [Int] = .init()
-  
+
   /** 处理buffer缓冲区情况 */
   private var currentInterval: UInt = 0
   private var callBackInterval: UInt = StreamingBuffer.defaultCallBackInterval
   private var updateInterval: UInt = StreamingBuffer.defaultUpdateInterval
   private var startTimer: Bool = false
+  private var tickTask: Task<Void, Never>?
   
   var isEmpty: Bool {
     list.isEmpty
@@ -98,53 +99,98 @@ actor StreamingBuffer {
   /** remove all objects from Buffer */
   func removeAll() {
     list.removeAll()
+    sortList.removeAll()
   }
-  
-  init() {
-    
+
+  func stopTick() {
+    tickTask?.cancel()
+    tickTask = nil
+    startTimer = false
   }
+
+  func setMaxCount(_ count: UInt) {
+    maxCount = count
+  }
+
+  init() {}
   
   private func removeExpireFrame() {
-    if list.count < maxCount {
+    if list.count < maxCount { return }
+
+    // Step 1: Drop orphaned P-frames that appear before the first I-frame (undecoded without prior I-frame)
+    let orphanedPFrames = expireOrphanedPFrames()
+    if !orphanedPFrames.isEmpty {
+      lastDropFrames += orphanedPFrames.count
+      let ts = Set(orphanedPFrames.map { $0.timestamp })
+      list = list.filter { !ts.contains($0.timestamp) }
       return
     }
-    ///< 第一个P到第一个I之间的p帧
-    let pFrames = expirePFrames()
-    lastDropFrames += pFrames.count
-    if !pFrames.isEmpty {
-      list = list.filter { value in
-        !pFrames.contains(where: { value.timestamp == $0.timestamp })
-      }
+
+    // Step 2: Drop P-frames within the oldest GOP (between first and second I-frame)
+    let gopPFrames = expireGOPPFrames()
+    if !gopPFrames.isEmpty {
+      lastDropFrames += gopPFrames.count
+      let ts = Set(gopPFrames.map { $0.timestamp })
+      list = list.filter { !ts.contains($0.timestamp) }
       return
     }
-    
-    ///<  删除一个I帧（但一个I帧可能对应多个nal）
-    let iFrames = expirePFrames()
+
+    // Step 3: Drop the first I-frame batch as last resort
+    let iFrames = expireIFrames()
     if !iFrames.isEmpty {
-      list = list.filter { value in
-        !iFrames.contains(where: { value.timestamp == $0.timestamp })
-      }
+      lastDropFrames += iFrames.count
+      let ts = Set(iFrames.map { $0.timestamp })
+      list = list.filter { !ts.contains($0.timestamp) }
       return
     }
-    
+
     list.removeAll()
   }
-  
-  private func expirePFrames() -> [any Frame] {
-    var iframes = [any Frame]()
-    var timestamp = UInt64(0)
-    
+
+  // P-frames that appear before the first I-frame (can't be decoded without a prior keyframe)
+  private func expireOrphanedPFrames() -> [any Frame] {
+    var result = [any Frame]()
     for frame in list {
-      if let frame = frame as? VideoFrame, frame.isKeyFrame {
-        if timestamp != 0 && timestamp != frame.timestamp {
-          break
-        }
-        iframes.append(frame)
-        timestamp = frame.timestamp
+      if let videoFrame = frame as? VideoFrame {
+        if videoFrame.isKeyFrame { break }
+        result.append(frame)
       }
     }
-    
-    return iframes
+    return result
+  }
+
+  // P-frames within the oldest GOP (between first I-frame and second I-frame)
+  private func expireGOPPFrames() -> [any Frame] {
+    var result = [any Frame]()
+    var foundFirstIFrame = false
+    for frame in list {
+      if let videoFrame = frame as? VideoFrame {
+        if videoFrame.isKeyFrame {
+          if foundFirstIFrame { break }
+          foundFirstIFrame = true
+        } else if foundFirstIFrame {
+          result.append(frame)
+        }
+      }
+    }
+    return result
+  }
+
+  // All frames belonging to the first I-frame group (same timestamp, one I-frame may span multiple NALs)
+  private func expireIFrames() -> [any Frame] {
+    var result = [any Frame]()
+    var targetTimestamp = UInt64(0)
+    for frame in list {
+      if let videoFrame = frame as? VideoFrame, videoFrame.isKeyFrame {
+        if targetTimestamp == 0 { targetTimestamp = videoFrame.timestamp }
+        if videoFrame.timestamp == targetTimestamp {
+          result.append(frame)
+        } else {
+          break
+        }
+      }
+    }
+    return result
   }
   
   func currentBufferState() -> BufferState {
@@ -174,11 +220,19 @@ actor StreamingBuffer {
   
   // -- 采样
   private func tick() {
-    /** 采样 3个阶段   如果网络都是好或者都是差给回调 */
+    tickTask = Task { [weak self] in
+      while !Task.isCancelled {
+        try? await Task.sleep(nanoseconds: UInt64(StreamingBuffer.defaultUpdateInterval) * 1_000_000_000)
+        guard !Task.isCancelled else { return }
+        await self?.sample()
+      }
+    }
+  }
+
+  private func sample() {
     currentInterval += updateInterval
-    
     thresholdList.append(list.count)
-    
+
     if currentInterval >= callBackInterval {
       let state = currentBufferState()
       if state == .increase {
@@ -186,14 +240,8 @@ actor StreamingBuffer {
       } else if state == .decline {
         delegate?.steamingBuffer(streamingBuffer: self, bufferState: .decline)
       }
-      
       currentInterval = 0
       thresholdList.removeAll()
-    }
-    
-    Task {
-      try? await Task.sleep(nanoseconds: UInt64(updateInterval) * 1000000)
-      tick()
     }
   }
   

--- a/Tests/HPLiveKitCoreTests/AudioResamplerTests.swift
+++ b/Tests/HPLiveKitCoreTests/AudioResamplerTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 import CoreMedia
 import AudioToolbox
-@testable import HPLiveKit
+@testable import HPLiveKitCore
 
 final class AudioResamplerTests: XCTestCase {
 

--- a/Tests/HPLiveKitCoreTests/AudioSampleBufferUtilsTests.swift
+++ b/Tests/HPLiveKitCoreTests/AudioSampleBufferUtilsTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 import CoreMedia
 import AudioToolbox
-@testable import HPLiveKit
+@testable import HPLiveKitCore
 
 final class AudioSampleBufferUtilsTests: XCTestCase {
 

--- a/Tests/HPLiveKitCoreTests/Helpers/AudioResamplerTestHelpers.swift
+++ b/Tests/HPLiveKitCoreTests/Helpers/AudioResamplerTestHelpers.swift
@@ -9,7 +9,7 @@ import Foundation
 import CoreMedia
 import AudioToolbox
 import AVFoundation
-@testable import HPLiveKit
+@testable import HPLiveKitCore
 
 /// Helper functions and utilities for AudioResampler testing
 enum AudioResamplerTestHelpers {

--- a/Tests/HPLiveKitCoreTests/LiveAudioConfigurationTests.swift
+++ b/Tests/HPLiveKitCoreTests/LiveAudioConfigurationTests.swift
@@ -1,0 +1,70 @@
+//
+//  LiveAudioConfigurationTests.swift
+//
+
+import XCTest
+@testable import HPLiveKitCore
+
+final class LiveAudioConfigurationTests: XCTestCase {
+
+    // MARK: - sampleRateIndex
+
+    func testSampleRateIndex_16000() {
+        XCTAssertEqual(LiveAudioSampleRate.s16000Hz.sampleRateIndex, 8)
+    }
+
+    func testSampleRateIndex_44100() {
+        XCTAssertEqual(LiveAudioSampleRate.s44100Hz.sampleRateIndex, 4)
+    }
+
+    func testSampleRateIndex_48000() {
+        XCTAssertEqual(LiveAudioSampleRate.s48000Hz.sampleRateIndex, 3)
+    }
+
+    // MARK: - Init stores values correctly
+
+    func testInit_StoresAllFields() {
+        let config = LiveAudioConfiguration(
+            numberOfChannels: 2,
+            audioSampleRate: .s44100Hz,
+            audioBitRate: .a128Kbps,
+            audioMixingEnabled: true,
+            appAudioVolume: 0.8,
+            micAudioVolume: 0.9
+        )
+        XCTAssertEqual(config.numberOfChannels, 2)
+        XCTAssertEqual(config.audioSampleRate, .s44100Hz)
+        XCTAssertEqual(config.audioBitRate, .a128Kbps)
+        XCTAssertTrue(config.audioMixingEnabled)
+        XCTAssertEqual(config.appAudioVolume, 0.8, accuracy: 0.001)
+        XCTAssertEqual(config.micAudioVolume, 0.9, accuracy: 0.001)
+    }
+
+    func testInit_DefaultMixingValues() {
+        let config = LiveAudioConfiguration(
+            numberOfChannels: 1,
+            audioSampleRate: .s48000Hz,
+            audioBitRate: .a96Kbps
+        )
+        XCTAssertTrue(config.audioMixingEnabled)
+        XCTAssertEqual(config.appAudioVolume, 0.6, accuracy: 0.001)
+        XCTAssertEqual(config.micAudioVolume, 1.0, accuracy: 0.001)
+    }
+
+    // MARK: - LiveAudioBitRate raw values
+
+    func testBitRateRawValues() {
+        XCTAssertEqual(LiveAudioBitRate.a32Kbps.rawValue, 32000)
+        XCTAssertEqual(LiveAudioBitRate.a64Kbps.rawValue, 64000)
+        XCTAssertEqual(LiveAudioBitRate.a96Kbps.rawValue, 96000)
+        XCTAssertEqual(LiveAudioBitRate.a128Kbps.rawValue, 128000)
+    }
+
+    // MARK: - LiveAudioSampleRate raw values
+
+    func testSampleRateRawValues() {
+        XCTAssertEqual(LiveAudioSampleRate.s16000Hz.rawValue, 16000)
+        XCTAssertEqual(LiveAudioSampleRate.s44100Hz.rawValue, 44100)
+        XCTAssertEqual(LiveAudioSampleRate.s48000Hz.rawValue, 48000)
+    }
+}

--- a/Tests/HPLiveKitCoreTests/LiveVideoConfigurationTests.swift
+++ b/Tests/HPLiveKitCoreTests/LiveVideoConfigurationTests.swift
@@ -1,0 +1,106 @@
+//
+//  LiveVideoConfigurationTests.swift
+//
+
+import XCTest
+@testable import HPLiveKitCore
+
+final class LiveVideoConfigurationTests: XCTestCase {
+
+    private func makeConfig(
+        size: CGSize = CGSize(width: 540, height: 960),
+        orientation: VideoOutputOrientation = .portrait,
+        respectAspectRatio: Bool = false,
+        preset: LiveVideoSessionPreset = .preset540x960
+    ) -> LiveVideoConfiguration {
+        LiveVideoConfiguration(
+            videoSize: size,
+            videoSizeRespectingAspectRatio: respectAspectRatio,
+            outputImageOrientation: orientation,
+            autorotate: true,
+            videoFrameRate: 30,
+            videoMinFrameRate: 15,
+            videoMaxFrameRate: 30,
+            videoBitRate: 800_000,
+            videoMaxBitRate: 1_000_000,
+            videoMinBitRate: 300_000,
+            sessionPreset: preset
+        )
+    }
+
+    func testIsLandscape_Portrait() {
+        let config = makeConfig(orientation: .portrait)
+        XCTAssertFalse(config.isLandscape)
+    }
+
+    func testIsLandscape_LandscapeLeft() {
+        let config = makeConfig(orientation: .landscapeLeft)
+        XCTAssertTrue(config.isLandscape)
+    }
+
+    func testIsLandscape_LandscapeRight() {
+        let config = makeConfig(orientation: .landscapeRight)
+        XCTAssertTrue(config.isLandscape)
+    }
+
+    func testOrientationFormatVideoSize_Portrait_Unchanged() {
+        let config = makeConfig(size: CGSize(width: 540, height: 960), orientation: .portrait)
+        XCTAssertEqual(config.orientationFormatVideoSize, CGSize(width: 540, height: 960))
+    }
+
+    func testOrientationFormatVideoSize_Landscape_Swapped() {
+        let config = makeConfig(size: CGSize(width: 540, height: 960), orientation: .landscapeLeft)
+        XCTAssertEqual(config.orientationFormatVideoSize, CGSize(width: 960, height: 540))
+    }
+
+    func testVideoMaxKeyframeInterval_IsDoubleFrameRate() {
+        let config = makeConfig()
+        XCTAssertEqual(config.videoMaxKeyframeInterval, 60) // 30 * 2
+    }
+
+    func testAspectRatioVideoSize_EvenDimensions() {
+        // 540x960 portrait, preset 540x960 → should fit exactly
+        let config = makeConfig(
+            size: CGSize(width: 540, height: 960),
+            orientation: .portrait,
+            respectAspectRatio: true,
+            preset: .preset540x960
+        )
+        let result = config.aspectRatioVideoSize
+        XCTAssertEqual(Int(result.width) % 2, 0, "Width must be even")
+        XCTAssertEqual(Int(result.height) % 2, 0, "Height must be even")
+    }
+
+    func testAspectRatioVideoSize_AlwaysEvenForLandscape() {
+        let config = makeConfig(
+            size: CGSize(width: 960, height: 540),
+            orientation: .landscapeLeft,
+            respectAspectRatio: true,
+            preset: .preset540x960
+        )
+        let result = config.aspectRatioVideoSize
+        XCTAssertEqual(Int(result.width) % 2, 0)
+        XCTAssertEqual(Int(result.height) % 2, 0)
+    }
+
+    func testInternalVideoSize_WithoutAspectRatio_UsesOrientationSize() {
+        let config = makeConfig(
+            size: CGSize(width: 540, height: 960),
+            orientation: .landscapeLeft,
+            respectAspectRatio: false
+        )
+        XCTAssertEqual(config.internalVideoSize, CGSize(width: 960, height: 540))
+    }
+
+    func testInternalVideoSize_WithAspectRatio_UsesAspectRatioSize() {
+        let config = makeConfig(
+            size: CGSize(width: 540, height: 960),
+            orientation: .portrait,
+            respectAspectRatio: true,
+            preset: .preset540x960
+        )
+        let result = config.internalVideoSize
+        // Should be the aspect-ratio-fitted size
+        XCTAssertEqual(result, config.aspectRatioVideoSize)
+    }
+}

--- a/Tests/HPLiveKitCoreTests/PublisherManagerTests.swift
+++ b/Tests/HPLiveKitCoreTests/PublisherManagerTests.swift
@@ -4,7 +4,7 @@
 //
 
 import XCTest
-@testable import HPLiveKit
+@testable import HPLiveKitCore
 
 // MARK: - Mock Publisher
 

--- a/Tests/HPLiveKitCoreTests/StreamingBufferTests.swift
+++ b/Tests/HPLiveKitCoreTests/StreamingBufferTests.swift
@@ -1,0 +1,139 @@
+//
+//  StreamingBufferTests.swift
+//
+
+import XCTest
+@testable import HPLiveKitCore
+
+final class StreamingBufferTests: XCTestCase {
+
+    private func makeVideo(ts: UInt64, isKey: Bool, data: Data? = Data([0x00])) -> VideoFrame {
+        VideoFrame(timestamp: ts, data: data, header: nil, isKeyFrame: isKey, compositionTime: 0, sps: nil, pps: nil)
+    }
+
+    private func makeAudio(ts: UInt64) -> AudioFrame {
+        AudioFrame(timestamp: ts, data: Data([0x01]), header: nil, aacHeader: nil)
+    }
+
+    // Append enough frames to fill one sort batch (default threshold = 5)
+    private func fillOneBatch(_ buf: StreamingBuffer) async {
+        for i in 0..<5 {
+            await buf.append(frame: makeVideo(ts: UInt64(i * 100), isKey: i == 0))
+        }
+    }
+
+    // MARK: - Basic operations
+
+    func testInitiallyEmpty() async {
+        let buf = StreamingBuffer()
+        let isEmpty = await buf.isEmpty
+        XCTAssertTrue(isEmpty)
+    }
+
+    func testAppendLessThanSortThreshold_ListRemainsEmpty() async {
+        let buf = StreamingBuffer()
+        for i in 0..<4 {
+            await buf.append(frame: makeVideo(ts: UInt64(i * 100), isKey: i == 0))
+        }
+        let count = await buf.list.count
+        XCTAssertEqual(count, 0)
+    }
+
+    func testAppendFiveFrames_OneMovedToList() async {
+        let buf = StreamingBuffer()
+        await fillOneBatch(buf)
+        let count = await buf.list.count
+        XCTAssertEqual(count, 1)
+    }
+
+    func testPopFirstFrame_RemovesFirstFrame() async {
+        let buf = StreamingBuffer()
+        await fillOneBatch(buf)
+        let frame = await buf.popFirstFrame()
+        XCTAssertNotNil(frame)
+        let remaining = await buf.list.count
+        XCTAssertEqual(remaining, 0)
+    }
+
+    func testPopFirstFrame_EmptyReturnsNil() async {
+        let buf = StreamingBuffer()
+        let frame = await buf.popFirstFrame()
+        XCTAssertNil(frame)
+    }
+
+    func testRemoveAll_ClearsBothLists() async {
+        let buf = StreamingBuffer()
+        // Fill list
+        for i in 0..<8 {
+            await buf.append(frame: makeVideo(ts: UInt64(i * 100), isKey: i == 0))
+        }
+        await buf.removeAll()
+        let listCount = await buf.list.count
+        XCTAssertEqual(listCount, 0)
+        // Appending fresh 5 frames should work correctly (sortList was also cleared)
+        for i in 0..<5 {
+            await buf.append(frame: makeVideo(ts: UInt64(1000 + i * 100), isKey: i == 0))
+        }
+        let afterRefill = await buf.list.count
+        XCTAssertEqual(afterRefill, 1)
+    }
+
+    // MARK: - Sorting
+
+    func testFramesAreSortedByTimestamp() async {
+        let buf = StreamingBuffer()
+        // Insert out of order — oldest should be in list after threshold
+        await buf.append(frame: makeVideo(ts: 400, isKey: false))
+        await buf.append(frame: makeVideo(ts: 100, isKey: true))
+        await buf.append(frame: makeVideo(ts: 300, isKey: false))
+        await buf.append(frame: makeVideo(ts: 200, isKey: false))
+        await buf.append(frame: makeVideo(ts: 500, isKey: false))
+        let frame = await buf.popFirstFrame()
+        XCTAssertEqual(frame?.timestamp, 100)
+    }
+
+    // MARK: - Expire frame logic (verifying C3 fix: P-frames drop before I-frames)
+
+    func testExpirePFrames_DropsNonKeyframesFirst() async {
+        let buf = StreamingBuffer()
+        // Lower maxCount to 5 so we can trigger expiry with fewer frames
+        await buf.setMaxCount(5)
+
+        // First batch: I P P P P → fills list to maxCount (5 frames)
+        for i in 0..<5 {
+            await buf.append(frame: makeVideo(ts: UInt64(i * 100), isKey: i == 0))
+        }
+
+        // Second batch starts; when the 5th frame is processed, removeExpireFrame is called
+        // because list.count (5) >= maxCount (5). It should drop P-frames (ts=100-400), not I-frame (ts=0).
+        await buf.append(frame: makeVideo(ts: 500, isKey: false))
+        await buf.append(frame: makeVideo(ts: 600, isKey: false))
+        await buf.append(frame: makeVideo(ts: 700, isKey: false))
+        await buf.append(frame: makeVideo(ts: 800, isKey: false))
+        await buf.append(frame: makeVideo(ts: 900, isKey: true)) // new I-frame
+
+        let list = await buf.list
+        let iFrames = list.compactMap { $0 as? VideoFrame }.filter { $0.isKeyFrame }
+        XCTAssertFalse(iFrames.isEmpty, "I-frame should survive; P-frames should be dropped first")
+    }
+
+    // MARK: - stopTick
+
+    func testStopTick_DoesNotCrash() async {
+        let buf = StreamingBuffer()
+        await fillOneBatch(buf)
+        await buf.stopTick()
+        // Appending after stop should still work
+        await buf.append(frame: makeVideo(ts: 600, isKey: false))
+        XCTAssertTrue(true)
+    }
+
+    // MARK: - ClearDropFrames
+
+    func testClearDropFramesCount_ResetsToZero() async {
+        let buf = StreamingBuffer()
+        await buf.clearDropFramesCount()
+        let count = await buf.lastDropFrames
+        XCTAssertEqual(count, 0)
+    }
+}

--- a/Tests/HPLiveKitCoreTests/TimestampSynchronizerTests.swift
+++ b/Tests/HPLiveKitCoreTests/TimestampSynchronizerTests.swift
@@ -1,0 +1,97 @@
+//
+//  TimestampSynchronizerTests.swift
+//
+
+import XCTest
+import CoreMedia
+@testable import HPLiveKitCore
+
+final class TimestampSynchronizerTests: XCTestCase {
+
+    private static func makeBuffer(pts seconds: Double) -> CMSampleBuffer {
+        let time = CMTime(seconds: seconds, preferredTimescale: 1000)
+        var timing = CMSampleTimingInfo(duration: .invalid, presentationTimeStamp: time, decodeTimeStamp: .invalid)
+        var formatDesc: CMFormatDescription!
+        var asbd = AudioStreamBasicDescription(
+            mSampleRate: 44100, mFormatID: kAudioFormatLinearPCM, mFormatFlags: 0,
+            mBytesPerPacket: 2, mFramesPerPacket: 1, mBytesPerFrame: 2,
+            mChannelsPerFrame: 1, mBitsPerChannel: 16, mReserved: 0
+        )
+        CMAudioFormatDescriptionCreate(allocator: nil, asbd: &asbd, layoutSize: 0, layout: nil, magicCookieSize: 0, magicCookie: nil, extensions: nil, formatDescriptionOut: &formatDesc)
+        var sampleBuffer: CMSampleBuffer!
+        CMSampleBufferCreate(allocator: nil, dataBuffer: nil, dataReady: true, makeDataReadyCallback: nil, refcon: nil, formatDescription: formatDesc, sampleCount: 0, sampleTimingEntryCount: 1, sampleTimingArray: &timing, sampleSizeEntryCount: 0, sampleSizeArray: nil, sampleBufferOut: &sampleBuffer)
+        return sampleBuffer
+    }
+
+    func testRecordIfNeeded_SetsBaseTimestamp() {
+        let sync = TimestampSynchronizer()
+        sync.recordIfNeeded(Self.makeBuffer(pts: 10.0))
+        // base = 10000ms; audio at 10000ms → normalized = 0
+        let audio = AudioFrame(timestamp: 10_000, data: nil, header: nil, aacHeader: nil)
+        XCTAssertEqual(sync.normalize(audio).timestamp, 0)
+    }
+
+    func testRecordIfNeeded_DoesNotOverwriteBase() {
+        let sync = TimestampSynchronizer()
+        sync.recordIfNeeded(Self.makeBuffer(pts: 5.0))
+        sync.recordIfNeeded(Self.makeBuffer(pts: 10.0)) // ignored
+        // base = 5000ms, frame at 10000ms → normalized = 5000
+        let audio = AudioFrame(timestamp: 10_000, data: nil, header: nil, aacHeader: nil)
+        XCTAssertEqual(sync.normalize(audio).timestamp, 5_000)
+    }
+
+    func testNormalizeAudio_CorrectOffset() {
+        let sync = TimestampSynchronizer()
+        sync.recordIfNeeded(Self.makeBuffer(pts: 2.0)) // base = 2000ms
+        let audio = AudioFrame(timestamp: 5_000, data: Data([1, 2, 3]), header: nil, aacHeader: nil)
+        let result = sync.normalize(audio)
+        XCTAssertEqual(result.timestamp, 3_000)
+        XCTAssertEqual(result.data, audio.data)
+    }
+
+    func testNormalizeVideo_CorrectOffset() {
+        let sync = TimestampSynchronizer()
+        sync.recordIfNeeded(Self.makeBuffer(pts: 1.0)) // base = 1000ms
+        let video = VideoFrame(timestamp: 4_000, data: Data([0xAA]), header: nil, isKeyFrame: true, compositionTime: 0, sps: nil, pps: nil)
+        let result = sync.normalize(video)
+        XCTAssertEqual(result.timestamp, 3_000)
+        XCTAssertTrue(result.isKeyFrame)
+    }
+
+    func testNormalize_ClampsUnderflowToZero() {
+        let sync = TimestampSynchronizer()
+        sync.recordIfNeeded(Self.makeBuffer(pts: 10.0)) // base = 10000ms
+        let audio = AudioFrame(timestamp: 5_000, data: nil, header: nil, aacHeader: nil) // ts < base
+        XCTAssertEqual(sync.normalize(audio).timestamp, 0)
+    }
+
+    func testNormalize_WithoutBase_ReturnsOriginal() {
+        let sync = TimestampSynchronizer()
+        let audio = AudioFrame(timestamp: 999, data: nil, header: nil, aacHeader: nil)
+        XCTAssertEqual(sync.normalize(audio).timestamp, 999)
+    }
+
+    func testReset_ClearsBaseTimestamp() {
+        let sync = TimestampSynchronizer()
+        sync.recordIfNeeded(Self.makeBuffer(pts: 5.0))
+        sync.reset()
+        // After reset, base is nil so normalize returns original
+        let audio = AudioFrame(timestamp: 5_000, data: nil, header: nil, aacHeader: nil)
+        XCTAssertEqual(sync.normalize(audio).timestamp, 5_000)
+    }
+
+    func testConcurrentAccess_NoDataRace() async {
+        let sync = TimestampSynchronizer()
+        // Concurrent normalize + reset — tests that the NSLock prevents data races
+        await withTaskGroup(of: Void.self) { group in
+            for i: UInt64 in 0..<100 {
+                group.addTask {
+                    let audio = AudioFrame(timestamp: i * 1000, data: nil, header: nil, aacHeader: nil)
+                    _ = sync.normalize(audio)
+                    if i % 20 == 0 { sync.reset() }
+                }
+            }
+        }
+        XCTAssertTrue(true, "No crash means thread safety is intact")
+    }
+}


### PR DESCRIPTION
## Summary

- **Critical bugs**: Fix nanosecond unit errors (reconnect waited 3ms instead of 3s, tick polled every 1ms instead of 1s); fix frame drop logic (3-step strategy: orphaned P-frames → GOP P-frames → I-frames); fix debugInfo self-assignment
- **Capture layer**: Replace 6 `fatalError` calls with warnings; fix `captureDevicePositionFront` toggle bug; fix `deinit` `[weak self]` issue that prevented `captureSession.stopRunning()`
- **Thread safety**: Add `NSLock` to `TimestampSynchronizer` and `LiveSession` shared state (`uploading`, `hasCapturedAudio`, etc.) accessed from multiple threads
- **Memory**: Fix `StreamingBuffer.tick()` recursive Task that leaked the actor; fix `LiveSession.deinit` not calling `encoder.stop()`; fix `removeAll()` not clearing `sortList`
- **Code quality**: Make `LiveDebug` properties `public`; narrow `FixedWidthInteger` extension; downgrade diagnostic log to `.debug`
- **CI**: Remove non-existent `Xcode_26.0.1.app` path; add `pull_request` trigger; add `swift test` step
- **Tests**: Fix `@testable import HPLiveKit` → `HPLiveKitCore`; add 35 new tests for `TimestampSynchronizer`, `StreamingBuffer`, `LiveVideoConfiguration`, `LiveAudioConfiguration` (66 total, up from 31)

## Test plan

- [x] `swift test --filter HPLiveKitCoreTests` — all 66 tests pass
- [x] `xcodebuild -scheme HPLiveKit-Package -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build` — BUILD SUCCEEDED